### PR TITLE
reduce usage of commons-lang to a minimum in order to minimize jar size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,33 +173,6 @@
           <minimizeJar>true</minimizeJar>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <createSourcesJar>true</createSourcesJar>
-          <artifactSet>
-            <includes>
-              <include>org.apache.commons:commons-lang3</include>
-            </includes>
-          </artifactSet>
-          <relocations>
-            <relocation>
-              <pattern>org.apache.commons.lang3.builder.</pattern>
-              <shadedPattern>org.apache.commons.text._lang3.builder.__</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.apache.commons.lang3.exception.</pattern>
-              <shadedPattern>org.apache.commons.text._lang3.exception.__</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.apache.commons.lang3.mutable.</pattern>
-              <shadedPattern>org.apache.commons.text._lang3.mutable.__</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.apache.commons.lang3.tuple.</pattern>
-              <shadedPattern>org.apache.commons.text._lang3.tuple.__</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.apache.commons.lang3.</pattern>
-              <shadedPattern>org.apache.commons.text._lang3.__</shadedPattern>
-            </relocation>
-          </relocations>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -19,9 +19,7 @@ package org.apache.commons.text;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
-
 import org.apache.commons.text.translate.AggregateTranslator;
 import org.apache.commons.text.translate.CharSequenceTranslator;
 import org.apache.commons.text.translate.EntityArrays;
@@ -47,6 +45,9 @@ import org.apache.commons.text.translate.UnicodeUnpairedSurrogateRemover;
  * @since 1.0
  */
 public class StringEscapeUtils {
+
+    private static final char LF = '\n';
+    private static final char CR = '\r';
 
     /* ESCAPE TRANSLATORS */
 
@@ -228,7 +229,7 @@ public class StringEscapeUtils {
         private static final char CSV_QUOTE = '"';
         private static final String CSV_QUOTE_STR = String.valueOf(CSV_QUOTE);
         private static final char[] CSV_SEARCH_CHARS =
-                new char[] {CSV_DELIMITER, CSV_QUOTE, CharUtils.CR, CharUtils.LF};
+                new char[] {CSV_DELIMITER, CSV_QUOTE, CR, LF};
 
         @Override
         public int translate(final CharSequence input, final int index, final Writer out) throws IOException {
@@ -381,7 +382,7 @@ public class StringEscapeUtils {
         private static final char CSV_QUOTE = '"';
         private static final String CSV_QUOTE_STR = String.valueOf(CSV_QUOTE);
         private static final char[] CSV_SEARCH_CHARS =
-                new char[] {CSV_DELIMITER, CSV_QUOTE, CharUtils.CR, CharUtils.LF};
+                new char[] {CSV_DELIMITER, CSV_QUOTE, CR, LF};
 
         @Override
         public int translate(final CharSequence input, final int index, final Writer out) throws IOException {

--- a/src/test/java/org/apache/commons/text/StrSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/text/StrSubstitutorTest.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -678,7 +677,12 @@ public class StrSubstitutorTest {
         }
 
         // replace using object
-        final MutableObject<String> obj = new MutableObject<>(replaceTemplate);  // toString returns template
+        final Object obj = new Object() {
+            @Override
+            public String toString() {
+                return replaceTemplate;
+            }
+        };
         assertEquals(expectedResult, sub.replace(obj));
 
         // replace in StringBuffer


### PR DESCRIPTION
sadly the shade plugin still includes a lot of classes