### PR TITLE
[TEXT-56] Move CvsTranslators out of StringEscapeUtils and make them DRY

### DIFF
--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.text;
 
-import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.translate.AggregateTranslator;
 import org.apache.commons.text.translate.CharSequenceTranslator;
+import org.apache.commons.text.translate.CsvTranslators;
 import org.apache.commons.text.translate.EntityArrays;
 import org.apache.commons.text.translate.JavaUnicodeEscaper;
 import org.apache.commons.text.translate.LookupTranslator;
@@ -254,36 +254,7 @@ public class StringEscapeUtils {
      * object allows the CSV escaping functionality to be used 
      * as the foundation for a custom translator.
      */
-    public static final CharSequenceTranslator ESCAPE_CSV = new CsvEscaper();
-
-    // TODO: Create a parent class - 'SinglePassTranslator' ?
-    //       It would handle the index checking + length returning, 
-    //       and could also have an optimization check method.
-    static class CsvEscaper extends CharSequenceTranslator {
-
-        private static final char CSV_DELIMITER = ',';
-        private static final char CSV_QUOTE = '"';
-        private static final String CSV_QUOTE_STR = String.valueOf(CSV_QUOTE);
-        private static final char[] CSV_SEARCH_CHARS =
-                new char[] {CSV_DELIMITER, CSV_QUOTE, CharUtils.CR, CharUtils.LF};
-
-        @Override
-        public int translate(final CharSequence input, final int index, final Writer out) throws IOException {
-
-            if(index != 0) {
-                throw new IllegalStateException("CsvEscaper should never reach the [1] index");
-            }
-
-            if (StringUtils.containsNone(input.toString(), CSV_SEARCH_CHARS)) {
-                out.write(input.toString());
-            } else {
-                out.write(CSV_QUOTE);
-                out.write(StringUtils.replace(input.toString(), CSV_QUOTE_STR, CSV_QUOTE_STR + CSV_QUOTE_STR));
-                out.write(CSV_QUOTE);
-            }
-            return Character.codePointCount(input, 0, input.length());
-        }
-    }
+    public static final CharSequenceTranslator ESCAPE_CSV = new CsvTranslators.CsvEscaper();
 
     /**
      * Translator object for escaping Shell command language.
@@ -410,40 +381,7 @@ public class StringEscapeUtils {
      * object allows the CSV unescaping functionality to be used 
      * as the foundation for a custom translator.
      */
-    public static final CharSequenceTranslator UNESCAPE_CSV = new CsvUnescaper();
-
-    static class CsvUnescaper extends CharSequenceTranslator {
-
-        private static final char CSV_DELIMITER = ',';
-        private static final char CSV_QUOTE = '"';
-        private static final String CSV_QUOTE_STR = String.valueOf(CSV_QUOTE);
-        private static final char[] CSV_SEARCH_CHARS =
-                new char[] {CSV_DELIMITER, CSV_QUOTE, CharUtils.CR, CharUtils.LF};
-
-        @Override
-        public int translate(final CharSequence input, final int index, final Writer out) throws IOException {
-
-            if(index != 0) {
-                throw new IllegalStateException("CsvUnescaper should never reach the [1] index");
-            }
-
-            if ( input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE ) {
-                out.write(input.toString());
-                return Character.codePointCount(input, 0, input.length());
-            }
-
-            // strip quotes
-            final String quoteless = input.subSequence(1, input.length() - 1).toString();
-
-            if ( StringUtils.containsAny(quoteless, CSV_SEARCH_CHARS) ) {
-                // deal with escaped quotes; ie) ""
-                out.write(StringUtils.replace(quoteless, CSV_QUOTE_STR + CSV_QUOTE_STR, CSV_QUOTE_STR));
-            } else {
-                out.write(input.toString());
-            }
-            return Character.codePointCount(input, 0, input.length());
-        }
-    }
+    public static final CharSequenceTranslator UNESCAPE_CSV = new CsvTranslators.CsvUnescaper();
 
     public static final CharSequenceTranslator UNESCAPE_XSI = new XsiUnescaper();
 

--- a/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
+++ b/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.translate;
+
+import org.apache.commons.lang3.CharUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * This class holds inner classes for escaping/unescaping Comma Separated Values.
+ */
+public class CsvTranslators {
+
+    private static final char CSV_DELIMITER = ',';
+    private static final char CSV_QUOTE = '"';
+    private static final String CSV_QUOTE_STR = String.valueOf(CSV_QUOTE);
+    private static final String CSV_ESCAPED_QUOTE_STR = CSV_QUOTE_STR + CSV_QUOTE_STR;
+    private static final char[] CSV_SEARCH_CHARS =
+            new char[] {CSV_DELIMITER, CSV_QUOTE, CharUtils.CR, CharUtils.LF};
+
+    private CsvTranslators() { }
+
+    /**
+     * Translator for escaping Comma Separated Values.
+     */
+    public static class CsvEscaper extends SinglePassTranslator {
+
+        @Override
+        void translateWhole(final CharSequence input, final Writer out) throws IOException {
+            final String inputSting = input.toString();
+            if (StringUtils.containsNone(inputSting, CSV_SEARCH_CHARS)) {
+                out.write(inputSting);
+            } else {
+                // input needs quoting
+                out.write(CSV_QUOTE);
+                out.write(StringUtils.replace(inputSting, CSV_QUOTE_STR, CSV_ESCAPED_QUOTE_STR));
+                out.write(CSV_QUOTE);
+            }
+        }
+    }
+
+    /**
+     * Translator for unescaping escaped Comma Separated Value entries.
+     */
+    public static class CsvUnescaper extends SinglePassTranslator {
+
+        @Override
+        void translateWhole(final CharSequence input, final Writer out) throws IOException {
+            // is input not quoted?
+            if (input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE) {
+                out.write(input.toString());
+                return;
+            }
+
+            // strip quotes
+            final String quoteless = input.subSequence(1, input.length() - 1).toString();
+
+            if (StringUtils.containsAny(quoteless, CSV_SEARCH_CHARS)) {
+                // deal with escaped quotes; ie) ""
+                out.write(StringUtils.replace(quoteless, CSV_ESCAPED_QUOTE_STR, CSV_QUOTE_STR));
+            } else {
+                out.write(input.toString());
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/text/translate/SinglePassTranslator.java
+++ b/src/main/java/org/apache/commons/text/translate/SinglePassTranslator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Abstract translator for processing whole input in single pass.
+ * Handles initial index checking and counting of returned code points.
+ */
+abstract class SinglePassTranslator extends CharSequenceTranslator {
+
+    @Override
+    public int translate(final CharSequence input, final int index, final Writer out) throws IOException {
+        if (index != 0) {
+            throw new IllegalStateException(getClassName() + " should never reach index different than 0");
+        }
+
+        translateWhole(input, out);
+
+        return Character.codePointCount(input, 0, input.length());
+    }
+
+    private String getClassName() {
+        final Class clazz = this.getClass();
+        return clazz.isAnonymousClass() ?  clazz.getName() : clazz.getSimpleName();
+    }
+
+    /**
+     * Translate whole set of code points passed in input.
+     *
+     * @param input CharSequence that is being translated
+     * @param out Writer to translate the text to
+     * @return total count of codepoints in input
+     * @throws IOException if and only if the Writer produces an IOException
+     */
+    abstract void translateWhole(final CharSequence input, final Writer out) throws IOException;
+}

--- a/src/test/java/org/apache/commons/text/translate/SinglePassTranslatorTest.java
+++ b/src/test/java/org/apache/commons/text/translate/SinglePassTranslatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.translate;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for {@link SinglePassTranslator}
+ */
+public class SinglePassTranslatorTest {
+
+    private final SinglePassTranslator dummyTranslator = new SinglePassTranslator() {
+        @Override
+        void translateWhole(final CharSequence input, final Writer out) throws IOException {
+        }
+    };
+
+    private StringWriter out;
+
+    @Before
+    public void before() {
+         out = new StringWriter();
+    }
+
+    @Test
+    public void codePointsAreReturned() throws Exception {
+        assertEquals(0, dummyTranslator.translate("", 0, out));
+        assertEquals(3, dummyTranslator.translate("abc", 0, out));
+        assertEquals(7, dummyTranslator.translate("abcdefg", 0, out));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void indexIsValidated() throws Exception {
+        dummyTranslator.translate("abc", 1, out);
+    }
+}


### PR DESCRIPTION
CvsEscaper/CvsUnescaper are currently inner classes of StringEscapeUtils and it does not seem like it is a proper place for them.
Since they are package-private, they can be safely moved lang.text.translate package.
Moreover it's possible make them more DRY by introducing SinlgePassTranslator as suggested in TODO.