### PR TITLE
TEXT-60: Upgrade Jacoco version for Java 9 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <commons.jacoco.version>0.7.8</commons.jacoco.version>
+  </properties>
+
   <distributionManagement>
     <site>
       <id>apache.website</id>


### PR DESCRIPTION
To support compiling against Java 9, the version of Jacoco must be upgraded.  This closes https://issues.apache.org/jira/browse/TEXT-60