### PR TITLE
Fixed checkstyle rule 'File does not end with a newline' on windows

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -63,7 +63,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+       <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->


### PR DESCRIPTION
With this rule change checkstyle will work fine on Windows and Linux both.