### PR TITLE
TEXT-89: WordUtils.initials support for UTF-16 surrogate pairs

### DIFF
--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -24,11 +24,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
 /**
- * <p>Operations on Strings that contain words.</p>
+ * <p>
+ * Operations on Strings that contain words.
+ * </p>
  *
- * <p>This class tries to handle <code>null</code> input gracefully.
- * An exception will not be thrown for a <code>null</code> input.
- * Each method documents its behaviour in more detail.</p>
+ * <p>
+ * This class tries to handle <code>null</code> input gracefully. An exception will not be thrown for a
+ * <code>null</code> input. Each method documents its behavior in more detail.
+ * </p>
  *
  * @since 1.1
  */
@@ -688,22 +691,22 @@ public class WordUtils {
             return "";
         }
         final int strLen = str.length();
-        final char[] buf = new char[strLen / 2 + 1];
+        final int [] newCodePoints = new int[strLen / 2 + 1];
         int count = 0;
         boolean lastWasGap = true;
-        for (int i = 0; i < strLen; i++) {
-            final char ch = str.charAt(i);
+        for (int i = 0; i < strLen;) {
+            final int codePoint = str.codePointAt(i);
 
-            if (isDelimiter(ch, delimiters)) {
+            if (isDelimiter(codePoint, delimiters)) {
                 lastWasGap = true;
             } else if (lastWasGap) {
-                buf[count++] = ch;
+                newCodePoints[count++] = codePoint;
                 lastWasGap = false;
-            } else {
-                continue; // ignore ch
             }
+
+            i += Character.charCount(codePoint);
         }
-        return new String(buf, 0, count);
+        return new String(newCodePoints, 0, count);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/WordUtilsTest.java
@@ -16,16 +16,13 @@
  */
 package org.apache.commons.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link WordUtils} class.
@@ -410,6 +407,23 @@ public class WordUtilsTest {
         assertEquals(" h", WordUtils.initials(" Ben   John  . Lee", array));
         assertEquals("K", WordUtils.initials("Kay O'Murphy", array));
         assertEquals("i2", WordUtils.initials("i am here 123", array));
+    }
+
+    @Test
+    public void testInitialsSurrogatePairs() {
+        //Tests with space as default delimiter
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00\uD800\uDF01 \uD800\uDF02\uD800\uDF03"));
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00\uD800\uDF01 \uD800\uDF02\uD800\uDF03", null));
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00 \uD800\uDF02 ", null));
+
+        //Tests with UTF-16 as delimiters
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00\uD800\uDF01.\uD800\uDF02\uD800\uDF03", new char[]{'.'}));
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00\uD800\uDF01A\uD800\uDF02\uD800\uDF03", new char[]{'A'}));
+
+        //Tests with UTF-32 as delimiters
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00\uD800\uDF01\uD800\uDF14\uD800\uDF02\uD800\uDF03", new char[]{'\uD800', '\uDF14'}));
+        assertEquals("\uD800\uDF00\uD800\uDF02", WordUtils.initials("\uD800\uDF00\uD800\uDF01\uD800\uDF14\uD800\uDF18\uD800\uDF02\uD800\uDF03", new char[]{'\uD800', '\uDF14', '\uD800', '\uDF18'}));
+
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
@chtompki Adding support for UTF-16 surrogate pairs to WordUtils.initials. Characters outside BMP can be used now and also added unit tests for surrogate pairs .