### PR TITLE
revert "Added IBM Jdk8 build support to travis-ci configuration"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,8 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
-services:
-  - docker
-
-before_install:
-  - docker pull ibmcom/ibmjava:8-sdk
-
 script:
   - mvn
-  - docker run -v `pwd`:/work library/ibmjava:8-sdk /bin/bash -c "apt-get update && cd work && apt-get install -y maven && mvn"
 
 after_success:
   - mvn clean test jacoco:report coveralls:report


### PR DESCRIPTION
The build fails, but this failure is not reflected in the travis build status. Code-coverage is broken.