### PR TITLE
TEXT-97: RandomStringGenerator able to pass multiple ranges to .withinRange()

### DIFF
--- a/src/main/java/org/apache/commons/text/RandomStringGenerator.java
+++ b/src/main/java/org/apache/commons/text/RandomStringGenerator.java
@@ -326,6 +326,36 @@ public final class RandomStringGenerator {
 
         /**
          * <p>
+         * Specifies the array of minimum and maximum char allowed in the
+         * generated string.
+         * </p>
+         *
+         * Ex.
+         * char [][] pairs = {{'0','9'}};
+         * char [][] pairs = {{'a','z'}};
+         * char [][] pairs = {{'a','z'},{'0','9'}};
+         *
+         * @param pairs array of charachters array, expected is to pass min, max pairs through this arg.
+         * @return {@code this}, to allow method chaining.
+         */
+        public Builder withinRange(final char[] ... pairs) {
+            characterList = new ArrayList<Character>();
+            for (char[] pair :  pairs) {
+                final int minimumCodePoint = pair[0];
+                final int maximumCodePoint = pair[1];
+                Validate.isTrue(minimumCodePoint <= maximumCodePoint,
+                    "Minimum code point %d is larger than maximum code point %d", minimumCodePoint, maximumCodePoint);
+
+                for (int index = minimumCodePoint; index <= maximumCodePoint; index++) {
+                    characterList.add((char) index);
+                }
+            }
+            return this;
+
+        }
+
+        /**
+         * <p>
          * Limits the characters in the generated string to those that match at
          * least one of the predicates supplied.
          * </p>

--- a/src/test/java/org/apache/commons/text/RandomStringGeneratorTest.java
+++ b/src/test/java/org/apache/commons/text/RandomStringGeneratorTest.java
@@ -112,6 +112,32 @@ public class RandomStringGeneratorTest {
     }
 
     @Test
+    public void testWithinMultipleRanges() {
+        final int length = 5000;
+        final char [][] pairs = {{'a','z'},{'0','9'}};
+        RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange(pairs).build();
+        String str = generator.generate(length);
+
+        int minimumCodePoint = 0, maximumCodePoint = 0;
+
+        for (char [] pair : pairs ) {
+            minimumCodePoint = Math.min(minimumCodePoint, pair[0]);
+            maximumCodePoint = Math.max(maximumCodePoint, pair[1]);
+        }
+
+        for (char [] pair : pairs ) {
+            int i = 0;
+            do {
+                int codePoint = str.codePointAt(i);
+                assertTrue(codePoint >= minimumCodePoint && codePoint <= maximumCodePoint);
+                i += Character.charCount(codePoint);
+            } while (i < str.length());
+        }
+    }
+
+
+
+    @Test
     public void testNoLoneSurrogates() {
         final int length = 5000;
         String str = new RandomStringGenerator.Builder().build().generate(length);


### PR DESCRIPTION
*.withinRange()* now able to accept multiple ranges.

Ex.
```
final char [][] pairs = {{'a','z'},{'0','9'}};
RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange(pairs).build();
```