### PR TITLE
add oraclejdk9 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@
 
 language: java
 sudo: false
+# trusty is required for oraclejdk9
+dist: trusty
 
 jdk:
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 
 script:
   - mvn

--- a/pom.xml
+++ b/pom.xml
@@ -450,5 +450,17 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java9</id>
+      <activation>
+        <jdk>9</jdk>
+      </activation>
+      <properties>
+        <!-- versions below 3.0.0 do not work with java 9 -->
+        <commons.javadoc.version>3.0.0-M1</commons.javadoc.version>
+        <!-- coverall version 4.3.0 does not work with java 9, see https://github.com/trautonen/coveralls-maven-plugin/issues/112 -->
+        <coveralls.skip>true</coveralls.skip>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
add maven java9 profile:
- use maven-javadoc-plugin version 3.0.0-M1, because versions below 3.0.0 do not work on java 9
- skip maven-coveralls-plugin, because version 4.3.0 does not work on java 9, see https://github.com/trautonen/coveralls-maven-plugin/issues/112