### PR TITLE
Fix typos, minor clean ups

### DIFF
--- a/src/main/java/org/apache/commons/text/AlphabetConverter.java
+++ b/src/main/java/org/apache/commons/text/AlphabetConverter.java
@@ -63,7 +63,7 @@ import java.util.Set;
  * </pre>
  *
  * <p>
- * #ThreadSafe# AlphabetConverter class methods are threadsafe as they do not
+ * #ThreadSafe# AlphabetConverter class methods are thread-safe as they do not
  * change internal state.
  * </p>
  *

--- a/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
@@ -320,10 +320,7 @@ public class ExtendedMessageFormat extends MessageFormat {
         if (!Objects.equals(toPattern, rhs.toPattern)) {
             return false;
         }
-        if (!Objects.equals(registry, rhs.registry)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(registry, rhs.registry);
     }
 
     /**

--- a/src/main/java/org/apache/commons/text/RandomStringGenerator.java
+++ b/src/main/java/org/apache/commons/text/RandomStringGenerator.java
@@ -337,7 +337,7 @@ public final class RandomStringGenerator {
          * }
          * </pre>
          *
-         * @param pairs array of charachters array, expected is to pass min, max pairs through this arg.
+         * @param pairs array of characters array, expected is to pass min, max pairs through this arg.
          * @return {@code this}, to allow method chaining.
          */
         public Builder withinRange(final char[] ... pairs) {
@@ -441,7 +441,7 @@ public final class RandomStringGenerator {
          * method will replace the previously stored Character.
          * </p>
          *
-         * @param chars set of preefined Characters for random string generation
+         * @param chars set of predefined Characters for random string generation
          *            the Character can be, may be {@code null} or empty
          * @return {@code this}, to allow method chaining
          * @since 1.2

--- a/src/main/java/org/apache/commons/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/text/StrBuilder.java
@@ -1158,7 +1158,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     public <T> StrBuilder appendAll(@SuppressWarnings("unchecked") final T... array) {
         /*
          * @SuppressWarnings used to hide warning about vararg usage. We cannot
-         * use @SafeVarargs, since this method is not final. Using @SupressWarnings
+         * use @SafeVarargs, since this method is not final. Using @SuppressWarnings
          * is fine, because it isn't inherited by subclasses, so each subclass must
          * vouch for itself whether its use of 'array' is safe.
          */

--- a/src/main/java/org/apache/commons/text/StrTokenizer.java
+++ b/src/main/java/org/apache/commons/text/StrTokenizer.java
@@ -865,7 +865,7 @@ public class StrTokenizer implements ListIterator<String>, Cloneable {
     /**
      * Sets the field delimiter matcher.
      * <p>
-     * The delimitier is used to separate one token from another.
+     * The delimiter is used to separate one token from another.
      *
      * @param delim  the delimiter matcher to use
      * @return this, to enable chaining

--- a/src/main/java/org/apache/commons/text/similarity/SimilarityScore.java
+++ b/src/main/java/org/apache/commons/text/similarity/SimilarityScore.java
@@ -41,7 +41,7 @@ package org.apache.commons.text.similarity;
  * Further, this intended to be BiFunction&lt;CharSequence, CharSequence, R&gt;.
  * The <code>apply</code> method
  * accepts a pair of {@link CharSequence} parameters
- * and returns an <code>R</code> type similarity score. We have ommitted the explicit
+ * and returns an <code>R</code> type similarity score. We have omitted the explicit
  * statement of extending BiFunction due to it only being implemented in Java 1.8, and we
  * wish to maintain Java 1.7 compatibility.
  * </p>

--- a/src/main/java/org/apache/commons/text/translate/LookupTranslator.java
+++ b/src/main/java/org/apache/commons/text/translate/LookupTranslator.java
@@ -43,7 +43,7 @@ public class LookupTranslator extends CharSequenceTranslator {
     /**
      * Define the lookup table to be used in translation
      *
-     * Note that, as of Lang 3.1 (the orgin of this code), the key to the lookup
+     * Note that, as of Lang 3.1 (the origin of this code), the key to the lookup
      * table is converted to a java.lang.String. This is because we need the key
      * to support hashCode and equals(Object), allowing it to be the key for a
      * HashMap. See LANG-882.

--- a/src/test/java/org/apache/commons/text/FormattableUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/FormattableUtilsTest.java
@@ -141,6 +141,6 @@ public class FormattableUtilsTest {
         public void formatTo(final Formatter formatter, final int flags, final int width, final int precision) {
             formatter.format(text);
         }
-    };
+    }
 
 }

--- a/src/test/java/org/apache/commons/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/StrBuilderTest.java
@@ -232,7 +232,7 @@ public class StrBuilderTest {
         assertTrue(sb.capacity() >= 32);
         assertEquals(3, sb.length());
         assertEquals(3, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.clear();
         assertTrue(sb.capacity() >= 32);
@@ -244,19 +244,19 @@ public class StrBuilderTest {
         assertTrue(sb.capacity() > 32);
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.ensureCapacity(16);
         assertTrue(sb.capacity() > 16);
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.minimizeCapacity();
         assertEquals(33, sb.capacity());
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         try {
             sb.setLength(-1);
@@ -269,21 +269,21 @@ public class StrBuilderTest {
         assertEquals(33, sb.capacity());
         assertEquals(33, sb.length());
         assertEquals(33, sb.size());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.setLength(16);
         assertTrue(sb.capacity() >= 16);
         assertEquals(16, sb.length());
         assertEquals(16, sb.size());
         assertEquals("1234567890123456", sb.toString());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.setLength(32);
         assertTrue(sb.capacity() >= 32);
         assertEquals(32, sb.length());
         assertEquals(32, sb.size());
         assertEquals("1234567890123456\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", sb.toString());
-        assertTrue(sb.isEmpty() == false);
+        assertFalse(sb.isEmpty());
 
         sb.setLength(0);
         assertTrue(sb.capacity() >= 32);


### PR DESCRIPTION
- simplify `if` condition with direct return
- fix some typos

Also I found a typo in public signature in `org.apache.commons.text.similarity.LongestCommonSubsequence#logestCommonSubsequence`:

    public CharSequence logestCommonSubsequence(final CharSequence left, final CharSequence right)

This one should be

    public CharSequence longestCommonSubsequence(final CharSequence left, final CharSequence right)

I did not touch it because it is public signature