### PR TITLE
TEXT-106: Exception thrown in ExtendedMessageFormat using quotes with custom registry

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
 
   <release version="1.2" date="2017-MM-DD" description="Release 1.2">
+    <action issue="TEXT-106" type="fix" dev="kinow" due-to="Benoit Moreau">Exception thrown in ExtendedMessageFormat using quotes with custom registry</action>
     <action issue="TEXT-100" type="fix" dev="kinow" due-to="Don Jeba">StringEscapeUtils#UnEscapeJson doesn't recognize escape signs correctly</action>
     <action issue="TEXT-74" type="add" dev="chtompki" due-to="Ioannis Sermetziadis">StrSubstitutor: Ability to turn off substitution in values</action>
     <action issue="TEXT-97" type="add" dev="chtompki" due-to="Amey Jadiye">RandomStringGenerator able to pass multiple ranges to .withinRange()</action>

--- a/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
@@ -411,21 +411,24 @@ public class ExtendedMessageFormat extends MessageFormat {
         seekNonWs(pattern, pos);
         final int text = pos.getIndex();
         int depth = 1;
-        for (; pos.getIndex() < pattern.length(); next(pos)) {
+        while (pos.getIndex() < pattern.length()) {
             switch (pattern.charAt(pos.getIndex())) {
             case START_FE:
                 depth++;
+                next(pos);
                 break;
             case END_FE:
                 depth--;
                 if (depth == 0) {
                     return pattern.substring(text, pos.getIndex());
                 }
+                next(pos);
                 break;
             case QUOTE:
                 getQuotedString(pattern, pos);
                 break;
             default:
+                next(pos);
                 break;
             }
         }

--- a/src/test/java/org/apache/commons/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/text/ExtendedMessageFormatTest.java
@@ -102,6 +102,17 @@ public class ExtendedMessageFormatTest {
     }
 
     /**
+     * Test Bug TEXT-106 - Exception while using ExtendedMessageFormat and choice format element with quote just before brace end
+     */
+    @Test
+    public void testChoiceQuoteJustBeforeBraceEnd_TEXT_106() {
+        final String pattern2 = "Message with choice format element with quote just before brace end ''{0,choice,0#0|0<'1'}''";
+        final ExtendedMessageFormat emf = new ExtendedMessageFormat(pattern2, registry);
+        assertEquals("Message with choice format element with quote just before brace end '0'", emf.format(new Object[] {0}));
+        assertEquals("Message with choice format element with quote just before brace end '1'", emf.format(new Object[] {1}));
+    }
+
+    /**
      * Test extended and built in formats.
      */
     @Test


### PR DESCRIPTION
Created this pull request from the patch provided by Benoît Moreau in [TEXT-106](https://issues.apache.org/jira/browse/TEXT-106).

Thanks for your contribution Benoît!

Cheers
Bruno