### PR TITLE
Add optimization to limited levenshtein distance

### DIFF
--- a/src/main/java/org/apache/commons/text/similarity/LevenshteinDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/LevenshteinDistance.java
@@ -241,6 +241,11 @@ public class LevenshteinDistance implements EditDistance<Integer> {
             m = right.length();
         }
 
+        // the edit distance cannot be less than the length difference
+        if (m - n > threshold) {
+            return -1;
+        }
+
         int[] p = new int[n + 1]; // 'previous' cost array, horizontally
         int[] d = new int[n + 1]; // cost array, horizontally
         int[] tempD; // placeholder to assist in swapping p and d


### PR DESCRIPTION
When the length difference exceeds the threshold, we can return -1 immediately skipping the algorithm. The reason is that the length difference is a lower bound of the unit-cost Levenshtein distance.