### PR TITLE
TEXT-138 TextStringBuilder append sub-sequence not consistant with Appendable

### DIFF
--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -711,7 +711,7 @@ public class StringSubstitutor {
         if (source == null) {
             return null;
         }
-        final TextStringBuilder buf = new TextStringBuilder(length).append(source, offset, length);
+        final TextStringBuilder buf = new TextStringBuilder(length).append(source.toString(), offset, length);
         substitute(buf, 0, length);
         return buf.toString();
     }

--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -128,7 +128,7 @@ import org.apache.commons.text.matcher.StringMatcherFactory;
  * to <b>true</b>.
  *
  * <code>StringSubstitutor</code> supports to throw exception if there are any resolved variables, this functionality
- * has to be enabled explicitly by setting the {@link #setFailOnUndefinedVariable(boolean) failOnUndefinedVariable} 
+ * has to be enabled explicitly by setting the {@link #setFailOnUndefinedVariable(boolean) failOnUndefinedVariable}
  * property to <b>true</b>.
  * <p>
  * This class is <b>not</b> thread safe.

--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -128,8 +128,8 @@ import org.apache.commons.text.matcher.StringMatcherFactory;
  * to <b>true</b>.
  *
  * <code>StringSubstitutor</code> supports to throw exception if there are any resolved variables, this functionality
- * has to be enabled explicitly by setting the {@link #setFailOnUndefinedVariable(boolean) failOnUndefinedVariable} property
- * to <b>true</b>.
+ * has to be enabled explicitly by setting the {@link #setFailOnUndefinedVariable(boolean) failOnUndefinedVariable} 
+ * property to <b>true</b>.
  * <p>
  * This class is <b>not</b> thread safe.
  * </p>
@@ -1425,10 +1425,8 @@ public class StringSubstitutor {
                                     lengthChange += change;
                                     chars = buf.buffer; // in case buffer was
                                                         // altered
-                                }
-                                else if (failOnUndefinedVariable){
-                                    throw new IllegalArgumentException
-                                    ("Not able to resolve all variables.");
+                                } else if (failOnUndefinedVariable) {
+                                    throw new IllegalArgumentException("Not able to resolve all variables.");
                                 }
 
                                 // remove variable from the cyclic stack

--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -126,6 +126,10 @@ import org.apache.commons.text.matcher.StringMatcherFactory;
  * <code>StringSubstitutor</code> supports this recursive substitution in variable names, but it has to be enabled
  * explicitly by setting the {@link #setEnableSubstitutionInVariables(boolean) enableSubstitutionInVariables} property
  * to <b>true</b>.
+ *
+ * <code>StringSubstitutor</code> supports to throw exception if there are any resolved variables, this functionality
+ * has to be enabled explicitly by setting the {@link #setFailOnUndefinedVariable(boolean) failOnUndefinedVariable} property
+ * to <b>true</b>.
  * <p>
  * This class is <b>not</b> thread safe.
  * </p>
@@ -290,6 +294,11 @@ public class StringSubstitutor {
      * The flag whether substitution in variable values is disabled.
      */
     private boolean disableSubstitutionInValues;
+
+    /**
+     * The flag whether exception should be thrown on undefined variable.
+     */
+    private boolean failOnUndefinedVariable;
 
     // -----------------------------------------------------------------------
     /**
@@ -600,6 +609,16 @@ public class StringSubstitutor {
     }
 
     /**
+     * Returns a flag whether exception can be thrown upon undefined
+     * variable.
+     *
+     * @return the fail on undefined variable flag
+     */
+    public boolean isFailOnUndefinedVariable() {
+        return failOnUndefinedVariable;
+    }
+
+    /**
      * Returns the flag controlling whether escapes are preserved during substitution.
      *
      * @return the preserve escape flag
@@ -616,6 +635,8 @@ public class StringSubstitutor {
      * @param source
      *            the character array to replace in, not altered, null returns null
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final char[] source) {
         if (source == null) {
@@ -640,6 +661,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final char[] source, final int offset, final int length) {
         if (source == null) {
@@ -657,6 +680,8 @@ public class StringSubstitutor {
      * @param source
      *            the buffer to use as a template, not changed, null returns null
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final CharSequence source) {
         if (source == null) {
@@ -679,6 +704,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final CharSequence source, final int offset, final int length) {
         if (source == null) {
@@ -697,6 +724,8 @@ public class StringSubstitutor {
      * @param source
      *            the source to replace in, null returns null
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final Object source) {
         if (source == null) {
@@ -715,6 +744,8 @@ public class StringSubstitutor {
      * @param source
      *            the builder to use as a template, not changed, null returns null
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final TextStringBuilder source) {
         if (source == null) {
@@ -739,6 +770,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the array to be processed, must be valid
      * @return the result of the replace operation
+      * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final TextStringBuilder source, final int offset, final int length) {
         if (source == null) {
@@ -757,6 +790,8 @@ public class StringSubstitutor {
      * @param source
      *            the string to replace in, null returns null
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final String source) {
         if (source == null) {
@@ -783,6 +818,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final String source, final int offset, final int length) {
         if (source == null) {
@@ -803,6 +840,8 @@ public class StringSubstitutor {
      * @param source
      *            the buffer to use as a template, not changed, null returns null
      * @return the result of the replace operation
+      * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final StringBuffer source) {
         if (source == null) {
@@ -827,6 +866,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the array to be processed, must be valid
      * @return the result of the replace operation
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public String replace(final StringBuffer source, final int offset, final int length) {
         if (source == null) {
@@ -845,6 +886,8 @@ public class StringSubstitutor {
      * @param source
      *            the builder to replace in, updated, null returns zero
      * @return true if altered
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public boolean replaceIn(final TextStringBuilder source) {
         if (source == null) {
@@ -867,6 +910,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the builder to be processed, must be valid
      * @return true if altered
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public boolean replaceIn(final TextStringBuilder source, final int offset, final int length) {
         if (source == null) {
@@ -905,6 +950,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the buffer to be processed, must be valid
      * @return true if altered
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public boolean replaceIn(final StringBuffer source, final int offset, final int length) {
         if (source == null) {
@@ -948,6 +995,8 @@ public class StringSubstitutor {
      * @param length
      *            the length within the buffer to be processed, must be valid
      * @return true if altered
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     public boolean replaceIn(final StringBuilder source, final int offset, final int length) {
         if (source == null) {
@@ -999,6 +1048,18 @@ public class StringSubstitutor {
      */
     public StringSubstitutor setDisableSubstitutionInValues(final boolean disableSubstitutionInValues) {
         this.disableSubstitutionInValues = disableSubstitutionInValues;
+        return this;
+    }
+
+    /**
+     * Sets a flag whether exception should be thrown if any variable is undefined.
+     *
+     * @param failOnUndefinedVariable
+     *            true if exception should be thrown on undefined variable
+     * @return this, to enable chaining
+     */
+    public StringSubstitutor setFailOnUndefinedVariable(final boolean failOnUndefinedVariable) {
+        this.failOnUndefinedVariable = failOnUndefinedVariable;
         return this;
     }
 
@@ -1244,6 +1305,8 @@ public class StringSubstitutor {
      *            the stack keeping track of the replaced variables, may be null
      * @return the length change that occurs, unless priorVariables is null when the int represents a boolean flag as to
      *         whether any change occurred.
+     * @throws IllegalArgumentException
+     *             if variable is not found when its allowed to throw exception
      */
     private int substitute(final TextStringBuilder buf, final int offset, final int length,
             List<String> priorVariables) {
@@ -1253,6 +1316,7 @@ public class StringSubstitutor {
         final StringMatcher valueDelimMatcher = getValueDelimiterMatcher();
         final boolean substitutionInVariablesEnabled = isEnableSubstitutionInVariables();
         final boolean substitutionInValuesDisabled = isDisableSubstitutionInValues();
+        final boolean failOnUndefinedVariable = isFailOnUndefinedVariable();
 
         final boolean top = priorVariables == null;
         boolean altered = false;
@@ -1361,6 +1425,10 @@ public class StringSubstitutor {
                                     lengthChange += change;
                                     chars = buf.buffer; // in case buffer was
                                                         // altered
+                                }
+                                else if (failOnUndefinedVariable){
+                                    throw new IllegalArgumentException
+                                    ("Not able to resolve all variables.");
                                 }
 
                                 // remove variable from the cyclic stack

--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -571,16 +571,22 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      *            the CharSequence to append
      * @param startIndex
      *            the start index, inclusive, must be valid
-     * @param length
-     *            the length to append, must be valid
+     * @param endIndex
+     *            the end index, exclusive, must be valid
      * @return this, to enable chaining
      */
     @Override
-    public TextStringBuilder append(final CharSequence seq, final int startIndex, final int length) {
+    public TextStringBuilder append(final CharSequence seq, final int startIndex, final int endIndex) {
         if (seq == null) {
             return appendNull();
         }
-        return append(seq.toString(), startIndex, length);
+        if (endIndex <= 0) {
+            throw new StringIndexOutOfBoundsException("endIndex must be valid");
+        }
+        if (startIndex >= endIndex) {
+            throw new StringIndexOutOfBoundsException("endIndex must be greater than startIndex");
+        }
+        return append(seq.toString(), startIndex, endIndex - startIndex);
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/StringSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/text/StringSubstitutorTest.java
@@ -346,7 +346,6 @@ public class StringSubstitutorTest {
         values.put("animal.2", "mouse");
         values.put("species", "2");
         final StringSubstitutor sub = new StringSubstitutor(values);
-
         sub.setEnableUndefinedVariableException(true);
 
         assertThatIllegalArgumentException().isThrownBy(() ->
@@ -383,7 +382,6 @@ public class StringSubstitutorTest {
         values.put("word", "variable");
         values.put("testok.2", "statement");
         final StringSubstitutor sub = new StringSubstitutor(values);
-
         sub.setEnableUndefinedVariableException(true);
         sub.setEnableSubstitutionInVariables(true);
 

--- a/src/test/java/org/apache/commons/text/TextStringBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderAppendInsertTest.java
@@ -206,13 +206,41 @@ public class TextStringBuilderAppendInsertTest {
             // expected
         }
 
+        try {
+            sb.append((CharSequence) "bar", 2, 1);
+            fail("append(char[], 2, 1) expected IndexOutOfBoundsException");
+        } catch (final IndexOutOfBoundsException e) {
+            // expected
+        }
+
+        try {
+            sb.append((CharSequence) "bar", 2, 2);
+            fail("append(char[], 2, 2) expected IndexOutOfBoundsException");
+        } catch (final IndexOutOfBoundsException e) {
+            // expected
+        }
+
+        try {
+            sb.append((CharSequence) "bar", 2, -2);
+            fail("append(char[], 2, -2) expected IndexOutOfBoundsException");
+        } catch (final IndexOutOfBoundsException e) {
+            // expected
+        }
+
+        try {
+            sb.append((CharSequence) "bar", 2, 0);
+            fail("append(char[], 2, 0) expected IndexOutOfBoundsException");
+        } catch (final IndexOutOfBoundsException e) {
+            // expected
+        }
+
         sb.append("bar", 3, 0);
         assertThat(sb.toString()).isEqualTo("foo");
 
         sb.append("abcbardef", 3, 3);
         assertThat(sb.toString()).isEqualTo("foobar");
 
-        sb.append((CharSequence) "abcbardef", 4, 3);
+        sb.append((CharSequence) "abcbardef", 4, 7);
         assertThat(sb.toString()).isEqualTo("foobarard");
     }
 


### PR DESCRIPTION
1 considered the end index as exclusive because its exclusive as per the definition done in Appendable.
2 considered start index not to be same as the end index because start index is inclusive, end index is not.
3 there is an overloaded append function in TextStringBuilder which takes String, int, int as parameters. The last parameter here is length. I didn't touch this because, its NOT an overridden function from Appendable.