### PR TITLE
TEXT-104: Jaro Winkler Distance refers to similarity

### DIFF
--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
@@ -16,55 +16,39 @@
  */
 package org.apache.commons.text.similarity;
 
-import java.util.Arrays;
-
 /**
- * A similarity algorithm indicating the percentage of matched characters between two character sequences.
- *
- * <p>
- * The Jaro measure is the weighted sum of percentage of matched characters
- * from each file and transposed characters. Winkler increased this measure
- * for matching initial characters.
- * </p>
- *
- * <p>
- * This implementation is based on the Jaro Winkler similarity algorithm
- * from <a href="http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance">
- * http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance</a>.
- * </p>
- *
- * <p>
- * This code has been adapted from Apache Commons Lang 3.3.
- * </p>
+ * Measures the Jaro-Winkler distance of two character sequences.
+ * It is the complementary of Jaro-Winkler similarity.
  *
  * @since 1.0
  */
-public class JaroWinklerDistance implements SimilarityScore<Double> {
+public class JaroWinklerDistance implements EditDistance<Double> {
 
     /**
-     * Represents a failed index search.
-     */
-    public static final int INDEX_NOT_FOUND = -1;
-
-    /**
-     * Find the Jaro Winkler Distance which indicates the similarity score
-     * between two CharSequences.
+     * Computes the Jaro Winkler Distance between two character sequences.
      *
      * <pre>
-     * distance.apply(null, null)          = IllegalArgumentException
-     * distance.apply("","")               = 0.0
-     * distance.apply("","a")              = 0.0
-     * distance.apply("aaapppp", "")       = 0.0
-     * distance.apply("frog", "fog")       = 0.93
-     * distance.apply("fly", "ant")        = 0.0
-     * distance.apply("elephant", "hippo") = 0.44
-     * distance.apply("hippo", "elephant") = 0.44
-     * distance.apply("hippo", "zzzzzzzz") = 0.0
-     * distance.apply("hello", "hallo")    = 0.88
-     * distance.apply("ABC Corporation", "ABC Corp") = 0.93
-     * distance.apply("D N H Enterprises Inc", "D &amp; H Enterprises, Inc.") = 0.95
-     * distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness") = 0.92
-     * distance.apply("PENNSYLVANIA", "PENNCISYLVNIA")    = 0.88
+     * sim.apply(null, null)          = IllegalArgumentException
+     * sim.apply("foo", null)         = IllegalArgumentException
+     * sim.apply(null, "foo")         = IllegalArgumentException
+     * sim.apply("", "")              = 0.0
+     * sim.apply("foo", "foo")        = 0.0
+     * sim.apply("foo", "foo ")       = 0.06
+     * sim.apply("foo", "foo  ")      = 0.09
+     * sim.apply("foo", " foo ")      = 0.13
+     * sim.apply("foo", "  foo")      = 0.49
+     * sim.apply("", "a")             = 1.0
+     * sim.apply("aaapppp", "")       = 1.0
+     * sim.apply("frog", "fog")       = 0.07
+     * sim.apply("fly", "ant")        = 1.0
+     * sim.apply("elephant", "hippo") = 0.56
+     * sim.apply("hippo", "elephant") = 0.56
+     * sim.apply("hippo", "zzzzzzzz") = 1.0
+     * sim.apply("hello", "hallo")    = 0.12
+     * sim.apply("ABC Corporation", "ABC Corp") = 0.07
+     * sim.apply("D N H Enterprises Inc", "D &amp; H Enterprises, Inc.") = 0.05
+     * sim.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness") = 0.08
+     * sim.apply("PENNSYLVANIA", "PENNCISYLVNIA") = 0.12
      * </pre>
      *
      * @param left the first CharSequence, must not be null
@@ -73,84 +57,13 @@ public class JaroWinklerDistance implements SimilarityScore<Double> {
      * @throws IllegalArgumentException if either CharSequence input is {@code null}
      */
     @Override
-    public Double apply(final CharSequence left, final CharSequence right) {
-        final double defaultScalingFactor = 0.1;
+    public Double apply(CharSequence left, CharSequence right) {
 
         if (left == null || right == null) {
             throw new IllegalArgumentException("CharSequences must not be null");
         }
 
-        final int[] mtp = matches(left, right);
-        final double m = mtp[0];
-        if (m == 0) {
-            return 0D;
-        }
-        final double j = ((m / left.length() + m / right.length() + (m - (double) mtp[1] / 2) / m)) / 3;
-        final double jw = j < 0.7D ? j : j + defaultScalingFactor * mtp[2] * (1D - j);
-        return jw;
+        JaroWinklerSimilarity jwSim = new JaroWinklerSimilarity();
+        return 1 - jwSim.apply(left, right);
     }
-
-    /**
-     * This method returns the Jaro-Winkler string matches, half transpositions, prefix array.
-     *
-     * @param first the first string to be matched
-     * @param second the second string to be matched
-     * @return mtp array containing: matches, half transpositions, and prefix
-     */
-    protected static int[] matches(final CharSequence first, final CharSequence second) {
-        CharSequence max, min;
-        if (first.length() > second.length()) {
-            max = first;
-            min = second;
-        } else {
-            max = second;
-            min = first;
-        }
-        final int range = Math.max(max.length() / 2 - 1, 0);
-        final int[] matchIndexes = new int[min.length()];
-        Arrays.fill(matchIndexes, -1);
-        final boolean[] matchFlags = new boolean[max.length()];
-        int matches = 0;
-        for (int mi = 0; mi < min.length(); mi++) {
-            final char c1 = min.charAt(mi);
-            for (int xi = Math.max(mi - range, 0), xn = Math.min(mi + range + 1, max.length()); xi < xn; xi++) {
-                if (!matchFlags[xi] && c1 == max.charAt(xi)) {
-                    matchIndexes[mi] = xi;
-                    matchFlags[xi] = true;
-                    matches++;
-                    break;
-                }
-            }
-        }
-        final char[] ms1 = new char[matches];
-        final char[] ms2 = new char[matches];
-        for (int i = 0, si = 0; i < min.length(); i++) {
-            if (matchIndexes[i] != -1) {
-                ms1[si] = min.charAt(i);
-                si++;
-            }
-        }
-        for (int i = 0, si = 0; i < max.length(); i++) {
-            if (matchFlags[i]) {
-                ms2[si] = max.charAt(i);
-                si++;
-            }
-        }
-        int halfTranspositions = 0;
-        for (int mi = 0; mi < ms1.length; mi++) {
-            if (ms1[mi] != ms2[mi]) {
-                halfTranspositions++;
-            }
-        }
-        int prefix = 0;
-        for (int mi = 0; mi < Math.min(4, min.length()); mi++) {
-            if (first.charAt(mi) == second.charAt(mi)) {
-                prefix++;
-            } else {
-                break;
-            }
-        }
-        return new int[] {matches, halfTranspositions, prefix};
-    }
-
 }

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
@@ -28,27 +28,27 @@ public class JaroWinklerDistance implements EditDistance<Double> {
      * Computes the Jaro Winkler Distance between two character sequences.
      *
      * <pre>
-     * sim.apply(null, null)          = IllegalArgumentException
-     * sim.apply("foo", null)         = IllegalArgumentException
-     * sim.apply(null, "foo")         = IllegalArgumentException
-     * sim.apply("", "")              = 0.0
-     * sim.apply("foo", "foo")        = 0.0
-     * sim.apply("foo", "foo ")       = 0.06
-     * sim.apply("foo", "foo  ")      = 0.09
-     * sim.apply("foo", " foo ")      = 0.13
-     * sim.apply("foo", "  foo")      = 0.49
-     * sim.apply("", "a")             = 1.0
-     * sim.apply("aaapppp", "")       = 1.0
-     * sim.apply("frog", "fog")       = 0.07
-     * sim.apply("fly", "ant")        = 1.0
-     * sim.apply("elephant", "hippo") = 0.56
-     * sim.apply("hippo", "elephant") = 0.56
-     * sim.apply("hippo", "zzzzzzzz") = 1.0
-     * sim.apply("hello", "hallo")    = 0.12
-     * sim.apply("ABC Corporation", "ABC Corp") = 0.07
-     * sim.apply("D N H Enterprises Inc", "D &amp; H Enterprises, Inc.") = 0.05
-     * sim.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness") = 0.08
-     * sim.apply("PENNSYLVANIA", "PENNCISYLVNIA") = 0.12
+     * distance.apply(null, null)          = IllegalArgumentException
+     * distance.apply("foo", null)         = IllegalArgumentException
+     * distance.apply(null, "foo")         = IllegalArgumentException
+     * distance.apply("", "")              = 0.0
+     * distance.apply("foo", "foo")        = 0.0
+     * distance.apply("foo", "foo ")       = 0.06
+     * distance.apply("foo", "foo  ")      = 0.09
+     * distance.apply("foo", " foo ")      = 0.13
+     * distance.apply("foo", "  foo")      = 0.49
+     * distance.apply("", "a")             = 1.0
+     * distance.apply("aaapppp", "")       = 1.0
+     * distance.apply("frog", "fog")       = 0.07
+     * distance.apply("fly", "ant")        = 1.0
+     * distance.apply("elephant", "hippo") = 0.56
+     * distance.apply("hippo", "elephant") = 0.56
+     * distance.apply("hippo", "zzzzzzzz") = 1.0
+     * distance.apply("hello", "hallo")    = 0.12
+     * distance.apply("ABC Corporation", "ABC Corp") = 0.07
+     * distance.apply("D N H Enterprises Inc", "D &amp; H Enterprises, Inc.") = 0.05
+     * distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness") = 0.08
+     * distance.apply("PENNSYLVANIA", "PENNCISYLVNIA") = 0.12
      * </pre>
      *
      * @param left the first CharSequence, must not be null

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
@@ -63,7 +63,7 @@ public class JaroWinklerDistance implements EditDistance<Double> {
             throw new IllegalArgumentException("CharSequences must not be null");
         }
 
-        JaroWinklerSimilarity jwSim = new JaroWinklerSimilarity();
-        return 1 - jwSim.apply(left, right);
+        JaroWinklerSimilarity similarity = new JaroWinklerSimilarity();
+        return 1 - similarity.apply(left, right);
     }
 }

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.similarity;
+
+import java.util.Arrays;
+
+/**
+ * A similarity algorithm indicating the percentage of matched characters between two character sequences.
+ *
+ * <p>
+ * The Jaro measure is the weighted sum of percentage of matched characters
+ * from each file and transposed characters. Winkler increased this measure
+ * for matching initial characters.
+ * </p>
+ *
+ * <p>
+ * This implementation is based on the Jaro Winkler similarity algorithm
+ * from <a href="http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance">
+ * http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance</a>.
+ * </p>
+ *
+ * <p>
+ * This code has been adapted from Apache Commons Lang 3.3.
+ * </p>
+ *
+ * @since 1.7
+ */
+public class JaroWinklerSimilarity implements SimilarityScore<Double> {
+
+    /**
+     * Computes the Jaro Winkler Similarity between two character sequences.
+     *
+     * <pre>
+     * sim.apply(null, null)          = IllegalArgumentException
+     * sim.apply("foo", null)         = IllegalArgumentException
+     * sim.apply(null, "foo")         = IllegalArgumentException
+     * sim.apply("", "")              = 1.0
+     * sim.apply("foo", "foo")        = 1.0
+     * sim.apply("foo", "foo ")       = 0.94
+     * sim.apply("foo", "foo  ")      = 0.91
+     * sim.apply("foo", " foo ")      = 0.87
+     * sim.apply("foo", "  foo")      = 0.51
+     * sim.apply("", "a")             = 0.0
+     * sim.apply("aaapppp", "")       = 0.0
+     * sim.apply("frog", "fog")       = 0.93
+     * sim.apply("fly", "ant")        = 0.0
+     * sim.apply("elephant", "hippo") = 0.44
+     * sim.apply("hippo", "elephant") = 0.44
+     * sim.apply("hippo", "zzzzzzzz") = 0.0
+     * sim.apply("hello", "hallo")    = 0.88
+     * sim.apply("ABC Corporation", "ABC Corp") = 0.93
+     * sim.apply("D N H Enterprises Inc", "D &amp; H Enterprises, Inc.") = 0.95
+     * sim.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness") = 0.92
+     * sim.apply("PENNSYLVANIA", "PENNCISYLVNIA") = 0.88
+     * </pre>
+     *
+     * @param left the first CharSequence, must not be null
+     * @param right the second CharSequence, must not be null
+     * @return result similarity
+     * @throws IllegalArgumentException if either CharSequence input is {@code null}
+     */
+    @Override
+    public Double apply(final CharSequence left, final CharSequence right) {
+        final double defaultScalingFactor = 0.1;
+
+        if (left == null || right == null) {
+            throw new IllegalArgumentException("CharSequences must not be null");
+        }
+
+        if (left.equals(right)) {
+            return 1D;
+        }
+
+        final int[] mtp = matches(left, right);
+        final double m = mtp[0];
+        if (m == 0) {
+            return 0D;
+        }
+        final double j = ((m / left.length() + m / right.length() + (m - (double) mtp[1] / 2) / m)) / 3;
+        final double jw = j < 0.7D ? j : j + defaultScalingFactor * mtp[2] * (1D - j);
+        return jw;
+    }
+
+    /**
+     * This method returns the Jaro-Winkler string matches, half transpositions, prefix array.
+     *
+     * @param first the first string to be matched
+     * @param second the second string to be matched
+     * @return mtp array containing: matches, half transpositions, and prefix
+     */
+    protected static int[] matches(final CharSequence first, final CharSequence second) {
+        CharSequence max, min;
+        if (first.length() > second.length()) {
+            max = first;
+            min = second;
+        } else {
+            max = second;
+            min = first;
+        }
+        final int range = Math.max(max.length() / 2 - 1, 0);
+        final int[] matchIndexes = new int[min.length()];
+        Arrays.fill(matchIndexes, -1);
+        final boolean[] matchFlags = new boolean[max.length()];
+        int matches = 0;
+        for (int mi = 0; mi < min.length(); mi++) {
+            final char c1 = min.charAt(mi);
+            for (int xi = Math.max(mi - range, 0), xn = Math.min(mi + range + 1, max.length()); xi < xn; xi++) {
+                if (!matchFlags[xi] && c1 == max.charAt(xi)) {
+                    matchIndexes[mi] = xi;
+                    matchFlags[xi] = true;
+                    matches++;
+                    break;
+                }
+            }
+        }
+        final char[] ms1 = new char[matches];
+        final char[] ms2 = new char[matches];
+        for (int i = 0, si = 0; i < min.length(); i++) {
+            if (matchIndexes[i] != -1) {
+                ms1[si] = min.charAt(i);
+                si++;
+            }
+        }
+        for (int i = 0, si = 0; i < max.length(); i++) {
+            if (matchFlags[i]) {
+                ms2[si] = max.charAt(i);
+                si++;
+            }
+        }
+        int halfTranspositions = 0;
+        for (int mi = 0; mi < ms1.length; mi++) {
+            if (ms1[mi] != ms2[mi]) {
+                halfTranspositions++;
+            }
+        }
+        int prefix = 0;
+        for (int mi = 0; mi < Math.min(4, min.length()); mi++) {
+            if (first.charAt(mi) == second.charAt(mi)) {
+                prefix++;
+            } else {
+                break;
+            }
+        }
+        return new int[] {matches, halfTranspositions, prefix};
+    }
+
+}

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java
@@ -82,16 +82,16 @@ public class JaroWinklerSimilarity implements SimilarityScore<Double> {
         }
 
         if (left.equals(right)) {
-            return 1D;
+            return 1d;
         }
 
         final int[] mtp = matches(left, right);
         final double m = mtp[0];
         if (m == 0) {
-            return 0D;
+            return 0d;
         }
         final double j = ((m / left.length() + m / right.length() + (m - (double) mtp[1] / 2) / m)) / 3;
-        final double jw = j < 0.7D ? j : j + defaultScalingFactor * mtp[2] * (1D - j);
+        final double jw = j < 0.7d ? j : j + defaultScalingFactor * mtp[2] * (1d - j);
         return jw;
     }
 

--- a/src/main/java/org/apache/commons/text/similarity/package-info.java
+++ b/src/main/java/org/apache/commons/text/similarity/package-info.java
@@ -29,6 +29,7 @@
  * <li>{@link org.apache.commons.text.similarity.FuzzyScore Fuzzy Score}</li>
  * <li>{@link org.apache.commons.text.similarity.HammingDistance Hamming Distance}</li>
  * <li>{@link org.apache.commons.text.similarity.JaroWinklerDistance Jaro-Winkler Distance}</li>
+ * <li>{@link org.apache.commons.text.similarity.JaroWinklerSimilarity Jaro-Winkler Similarity}</li>
  * <li>{@link org.apache.commons.text.similarity.LevenshteinDistance Levenshtein Distance}</li>
  * <li>{@link org.apache.commons.text.similarity.LongestCommonSubsequenceDistance
  * Longest Commons Subsequence Distance}</li>

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -112,7 +112,8 @@ limitations under the License.
           <ul>
             <li>Cosine Similarity,</li>
             <li>Fuzzy Score Similarity,</li>
-            <li>Jaccard Similarity, and</li>
+            <li>Jaccard Similarity,</li>
+            <li>Jaro-Winkler Similarity, and</li>               
             <li>Longest Common Subsequence Similarity.</li>
           </ul>
         </p>
@@ -181,6 +182,9 @@ limitations under the License.
         <li>
           <code>JaroWinklerDistance</code>
         </li>
+        <li>
+          <code>JaroWinklerSimilarity</code>
+        </li>           
         <li>
           <code>LevenshteinDistance</code>
         </li>

--- a/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
@@ -36,17 +36,23 @@ public class JaroWinklerDistanceTest {
 
     @Test
     public void testGetJaroWinklerDistance_StringString() {
-        assertEquals(0.92499d, distance.apply("frog", "fog"), 0.00001d);
-        assertEquals(0.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
-        assertEquals(0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
-        assertEquals(0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
-        assertEquals(0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
-        assertEquals(0.942d,
+        assertEquals(0d, distance.apply("", ""), 0.00001d);
+        assertEquals(0d, distance.apply("foo", "foo"), 0.00001d);
+        assertEquals(1 - 0.94166d, distance.apply("foo", "foo "), 0.00001d);
+        assertEquals(1 - 0.90666d, distance.apply("foo", "foo  "), 0.00001d);
+        assertEquals(1 - 0.86666d, distance.apply("foo", " foo "), 0.00001d);
+        assertEquals(1 - 0.51111d, distance.apply("foo", "  foo"), 0.00001d);
+        assertEquals(1 - 0.92499d, distance.apply("frog", "fog"), 0.00001d);
+        assertEquals(1.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
+        assertEquals(1 - 0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
+        assertEquals(1 - 0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
+        assertEquals(1 - 0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
+        assertEquals(1 - 0.942d,
                 distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
-        assertEquals(0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
-        assertEquals(0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
-        assertEquals(0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
-        assertEquals(0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
+        assertEquals(1 - 0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
+        assertEquals(1 - 0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
+        assertEquals(1 - 0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
+        assertEquals(1 - 0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/text/similarity/JaroWinklerSimilarityTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaroWinklerSimilarityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.similarity;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link JaroWinklerSimilarity}.
+ */
+public class JaroWinklerSimilarityTest {
+
+    private static JaroWinklerSimilarity similarity;
+
+    @BeforeAll
+    public static void setUp() {
+        similarity = new JaroWinklerSimilarity();
+    }
+
+    @Test
+    public void testGetJaroWinklerSimilarity_StringString() {
+        assertEquals(1d, similarity.apply("", ""), 0.00001d);
+        assertEquals(1d, similarity.apply("foo", "foo"), 0.00001d);
+        assertEquals(0.94166d, similarity.apply("foo", "foo "), 0.00001d);
+        assertEquals(0.90666d, similarity.apply("foo", "foo  "), 0.00001d);
+        assertEquals(0.86666d, similarity.apply("foo", " foo "), 0.00001d);
+        assertEquals(0.51111d, similarity.apply("foo", "  foo"), 0.00001d);
+        assertEquals(0.92499d, similarity.apply("frog", "fog"), 0.00001d);
+        assertEquals(0.0d, similarity.apply("fly", "ant"), 0.00000000000000000001d);
+        assertEquals(0.44166d, similarity.apply("elephant", "hippo"), 0.00001d);
+        assertEquals(0.90666d, similarity.apply("ABC Corporation", "ABC Corp"), 0.00001d);
+        assertEquals(0.95251d, similarity.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
+        assertEquals(0.942d,
+                similarity.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
+        assertEquals(0.898018d, similarity.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
+        assertEquals(0.971428d, similarity.apply("/opt/software1", "/opt/software2"), 0.00001d);
+        assertEquals(0.941666d, similarity.apply("aaabcd", "aaacdb"), 0.00001d);
+        assertEquals(0.911111d, similarity.apply("John Horn", "John Hopkins"), 0.00001d);
+    }
+
+    @Test
+    public void testGetJaroWinklerSimilarity_NullNull() {
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+            similarity.apply(null, null);
+        });
+    }
+
+    @Test
+    public void testGetJaroWinklerSimilarity_StringNull() {
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+            similarity.apply(" ", null);
+        });
+    }
+
+    @Test
+    public void testGetJaroWinklerSimilarity_NullString() {
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+            similarity.apply(null, "clear");
+        });
+    }
+
+}


### PR DESCRIPTION
Provide class `JaroWinklerSimilarity` to compute JW similarity (reuses protected methods of `JaroWinklerDistance`). Changed the implementation of `JaroWinklerDistance` as it was computing similarity instead of distance values. Improved handling of equal character sequences.