### PR TITLE
TEXT-104: deprecate JaroWinkler methods for 2.0, and fix clirr report

### DIFF
--- a/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
@@ -36,23 +36,34 @@ public class JaroWinklerDistanceTest {
 
     @Test
     public void testGetJaroWinklerDistance_StringString() {
-        assertEquals(0d, distance.apply("", ""), 0.00001d);
-        assertEquals(0d, distance.apply("foo", "foo"), 0.00001d);
-        assertEquals(1 - 0.94166d, distance.apply("foo", "foo "), 0.00001d);
-        assertEquals(1 - 0.90666d, distance.apply("foo", "foo  "), 0.00001d);
-        assertEquals(1 - 0.86666d, distance.apply("foo", " foo "), 0.00001d);
-        assertEquals(1 - 0.51111d, distance.apply("foo", "  foo"), 0.00001d);
-        assertEquals(1 - 0.92499d, distance.apply("frog", "fog"), 0.00001d);
-        assertEquals(1.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
-        assertEquals(1 - 0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
-        assertEquals(1 - 0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
-        assertEquals(1 - 0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
-        assertEquals(1 - 0.942d,
-                distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
-        assertEquals(1 - 0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
-        assertEquals(1 - 0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
-        assertEquals(1 - 0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
-        assertEquals(1 - 0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
+        assertEquals(0.92499d, distance.apply("frog", "fog"), 0.00001d);
+        assertEquals(0.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
+        assertEquals(0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
+        assertEquals(0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
+        assertEquals(0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
+        assertEquals(0.942d, distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
+        assertEquals(0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
+        assertEquals(0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
+        assertEquals(0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
+        assertEquals(0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
+        // TODO: replace tests in 2.0. See TEXT-104 for more.
+        // assertEquals(0d, distance.apply("", ""), 0.00001d);
+        // assertEquals(0d, distance.apply("foo", "foo"), 0.00001d);
+        // assertEquals(1 - 0.94166d, distance.apply("foo", "foo "), 0.00001d);
+        // assertEquals(1 - 0.90666d, distance.apply("foo", "foo  "), 0.00001d);
+        // assertEquals(1 - 0.86666d, distance.apply("foo", " foo "), 0.00001d);
+        // assertEquals(1 - 0.51111d, distance.apply("foo", "  foo"), 0.00001d);
+        // assertEquals(1 - 0.92499d, distance.apply("frog", "fog"), 0.00001d);
+        // assertEquals(1.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
+        // assertEquals(1 - 0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
+        // assertEquals(1 - 0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
+        // assertEquals(1 - 0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
+        // assertEquals(1 - 0.942d,
+        //         distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
+        // assertEquals(1 - 0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
+        // assertEquals(1 - 0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
+        // assertEquals(1 - 0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
+        // assertEquals(1 - 0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
     }
 
     @Test


### PR DESCRIPTION
This PR makes the Clirr report pass for 1.7. It keeps the new `JaroWinklerSimilarity` class, but reverts the change in `JaroWinklerDistance`. This way we keep backward feature and binary compatibility.

Also added `TODO`'s in the code for 2.0, and if others are OK with this pull request, I will create a Task ticket in JIRA for 2.0, so that when a release manager performs the release, s/he won't forget to look at the TODO and update the code.

@saschaszott I feel bad reverting part of your change, but it will be fully available in an upcoming 2.0 release :)

Cheers
Bruno