### PR TITLE
TEXT-152 - new tests and fix for infinite loop

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,6 +51,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action issue="TEXT-148" type="add" dev="ggregory">Add an enum to the lookup package that lists all StringLookups</action>
     <action issue="TEXT-127" type="add" dev="ggregory" due-to="Jean-Baptiste REICH, Sebb, Don Jeba, Gary Gregory">Add a toggle to throw an exception when a variable is unknown in StringSubstitutor</action>
     <action issue="TEXT-138" type="add" dev="ggregory" due-to="Neal Johnson, Don Jeba">TextStringBuilder append sub-sequence not consistent with Appendable.</action>
+    <action issue="TEXT-152" type="add" dev="" due-to="@CAPS50">Fix possible infinite loop in WordUtils.wrap for a regex pattern that would trigger on a match of 0 length</action>
   </release>
 
   <release version="1.6" date="2018-10-12" description="Release 1.6">

--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -313,8 +313,7 @@ public class WordUtils {
                     if (matcherSize != 0) {
                         offset += matcher.end();
                         continue;
-                    }
-                    else {
+                    } else {
                         offset += 1;
                     }
                 }

--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -310,8 +310,13 @@ public class WordUtils {
             if (matcher.find()) {
                 if (matcher.start() == 0) {
                     matcherSize = matcher.end() - matcher.start();
-                    offset += matcher.end();
-                    continue;
+                    if (matcherSize != 0) {
+                        offset += matcher.end();
+                        continue;
+                    }
+                    else {
+                        offset += 1;
+                    }
                 }
                 spaceToWrapAt = matcher.start() + offset;
             }
@@ -334,6 +339,9 @@ public class WordUtils {
             } else {
                 // really long word or URL
                 if (wrapLongWords) {
+                    if (matcherSize == 0) {
+                        offset--;
+                    }
                     // wrap really long word one line at a time
                     wrappedLine.append(str, offset, wrapLength + offset);
                     wrappedLine.append(newLineStr);
@@ -348,10 +356,16 @@ public class WordUtils {
                     }
 
                     if (spaceToWrapAt >= 0) {
+                        if (matcherSize == 0 && offset != 0) {
+                            offset--;
+                        }
                         wrappedLine.append(str, offset, spaceToWrapAt);
                         wrappedLine.append(newLineStr);
                         offset = spaceToWrapAt + 1;
                     } else {
+                        if (matcherSize == 0 && offset != 0) {
+                            offset--;
+                        }
                         wrappedLine.append(str, offset, str.length());
                         offset = inputLineLength;
                         matcherSize = -1;
@@ -360,7 +374,7 @@ public class WordUtils {
             }
         }
 
-        if (matcherSize == 0) {
+        if (matcherSize == 0 && offset < inputLineLength) {
             offset--;
         }
 

--- a/src/test/java/org/apache/commons/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/WordUtilsTest.java
@@ -545,4 +545,20 @@ public class WordUtilsTest {
     }
 
 
+
+    @Test
+    public void testWrapAtStartAndEnd() {
+        assertThat(WordUtils.wrap("nabcdefabcdefn", 2, "\n", false, "(?=n)")).isEqualTo("\nabcdefabcdef\n");
+    }
+
+    @Test
+    public void testWrapWithMultipleRegexMatchOfLength0() {
+        assertThat(WordUtils.wrap("abcdefabcdef", 2, "\n", false, "(?=d)")).isEqualTo("abc\ndefabc\ndef");
+    }
+
+    @Test
+    public void testWrapAtMiddleTwice() {
+        assertThat(WordUtils.wrap("abcdefggabcdef", 2, "\n", false, "(?=g)")).isEqualTo("abcdef\n\nabcdef");
+    }
+
 }


### PR DESCRIPTION
Hi, I have added a test that show shows the infinite loop, and the code that fixes it.

In order to make the test pass, and not only make the infinite loop stop happening, more changes were needed because the code for TEXT-111 did not fix the replacement of 0 length matches when we have multiple matches.