### PR TITLE
(doc) Fix typo in similarity package docs

### DIFF
--- a/src/main/java/org/apache/commons/text/similarity/package-info.java
+++ b/src/main/java/org/apache/commons/text/similarity/package-info.java
@@ -32,7 +32,7 @@
  * <li>{@link org.apache.commons.text.similarity.JaroWinklerSimilarity Jaro-Winkler Similarity}</li>
  * <li>{@link org.apache.commons.text.similarity.LevenshteinDistance Levenshtein Distance}</li>
  * <li>{@link org.apache.commons.text.similarity.LongestCommonSubsequenceDistance
- * Longest Commons Subsequence Distance}</li>
+ * Longest Common Subsequence Distance}</li>
  * </ul>
  *
  * <p>The {@link org.apache.commons.text.similarity.CosineDistance Cosine Distance}


### PR DESCRIPTION
Thanks for the library! Noticed an extra 's' in 'Longest Commons Subsequence Distance' in the javadocs for `org.apache.commons.text.similarity`.

Changes:
"Longest Commons Subsequence Distance" -> "Longest Common Subsequence Distance"