### PR TITLE
 Fix length change omission for StringSubstitutor cyclic detection 

### DIFF
--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -1408,7 +1408,7 @@ public class StringSubstitutor {
                                 // on the first call initialize priorVariables
                                 if (priorVariables == null) {
                                     priorVariables = new ArrayList<>();
-                                    priorVariables.add(new String(chars, offset, length));
+                                    priorVariables.add(new String(chars, offset, length + lengthChange));
                                 }
 
                                 // handle cyclic substitution


### PR DESCRIPTION
`StringSubstitutor#substitute` would throw `StringIndexOutOfBoundsException` when removing a variable start marker if `StringSubstitutor` wasn't using the internal representation of  `TextStringBuilder#buffer`. The local variable, `priorVariables`, contains unbalanced squirrely parentheses (replacing `$${${TEST}}` would cause `priorVariables` to add `${${TEST}}}` -- amusingly didn't result in unexpected behavior). I discovered this when swapping all instances of `buf.buffer` to `buf.toCharArray()`. This PR ensures that both now have equivalent behavior. I was unable to tease out a test for this, as the length is only decremented to that point (but this change in length goes unused, hence the exception for `toCharArray`), so no overflows. I did port a test from `StrSubstitutorTest.java`, but the test passes before and after this change.

I believe this to be a trivial change (hence no JIRA ticket). Let me know if otherwise