### PR TITLE
TEXT-149: StringEscapeUtils.unescapeCsv doesn't remove quotes at begin and end of string

### DIFF
--- a/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
+++ b/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
@@ -87,7 +87,7 @@ public final class CsvTranslators {
                 // deal with escaped quotes; ie) ""
                 out.write(StringUtils.replace(quoteless, CSV_ESCAPED_QUOTE_STR, CSV_QUOTE_STR));
             } else {
-                out.write(input.toString());
+                out.write(quoteless.toString());
             }
         }
     }

--- a/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
+++ b/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
@@ -87,7 +87,7 @@ public final class CsvTranslators {
                 // deal with escaped quotes; ie) ""
                 out.write(StringUtils.replace(quoteless, CSV_ESCAPED_QUOTE_STR, CSV_QUOTE_STR));
             } else {
-                out.write(quoteless.toString());
+                out.write(quoteless);
             }
         }
     }

--- a/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
@@ -460,7 +460,7 @@ public class StringEscapeUtilsTest {
         assertEquals("", StringEscapeUtils.unescapeCsv(""));
         assertNull(StringEscapeUtils.unescapeCsv(null));
 
-        assertEquals("\"foo.bar\"", StringEscapeUtils.unescapeCsv("\"foo.bar\""));
+        assertEquals("foo.bar", StringEscapeUtils.unescapeCsv("\"foo.bar\""));
     }
 
     @Test
@@ -474,7 +474,7 @@ public class StringEscapeUtilsTest {
         checkCsvUnescapeWriter("", null);
         checkCsvUnescapeWriter("", "");
 
-        checkCsvUnescapeWriter("\"foo.bar\"", "\"foo.bar\"");
+        checkCsvUnescapeWriter("foo.bar", "\"foo.bar\"");
     }
 
     private void checkCsvUnescapeWriter(final String expected, final String value) {


### PR DESCRIPTION
Fixed StringEscapeUtils.unescapeCsv remove quotes at begin and end of string.

"foo,bar" -> foo,bar
