### PR TITLE
Text 174: ScriptStringLookup does not accept ":"

### DIFF
--- a/src/main/java/org/apache/commons/text/lookup/ScriptStringLookup.java
+++ b/src/main/java/org/apache/commons/text/lookup/ScriptStringLookup.java
@@ -25,9 +25,9 @@ import javax.script.ScriptEngineManager;
 import org.apache.commons.text.StringSubstitutor;
 
 /**
- * Looks up keys from an XML document.
+ * Executes the script with the given engine name.
  * <p>
- * Looks up the value for a given key in the format "Document:Key".
+ * Execute the script with the engine name in the format "EngineName:Script".
  * </p>
  * <p>
  * For example: {@code "javascript:3 + 4"}.
@@ -55,14 +55,15 @@ final class ScriptStringLookup extends AbstractStringLookup {
     }
 
     /**
-     * Looks up the value for the key in the format "DocumentPath:XPath".
+     * Execute the script with the engine name in the format "EngineName:Script".
+     * Extra colons will be ignored.
      * <p>
-     * For example: "com/domain/document.xml:/path/to/node".
+     * For example: {@code "javascript:3 + 4"}.
      * </p>
      *
      * @param key
-     *            the key to be looked up, may be null
-     * @return The value associated with the key.
+     *            the engine:script to execute, may be null
+     * @return The value returned by the execution.
      */
     @Override
     public String lookup(final String key) {
@@ -72,7 +73,7 @@ final class ScriptStringLookup extends AbstractStringLookup {
         final String[] keys = key.split(SPLIT_STR, 2);
         final int keyLen = keys.length;
         if (keyLen != 2) {
-            throw IllegalArgumentExceptions.format("Bad script key format [%s]; expected format is DocumentPath:Key.",
+            throw IllegalArgumentExceptions.format("Bad script key format [%s]; expected format is EngineName:Script.",
                     key);
         }
         final String engineName = keys[0];

--- a/src/main/java/org/apache/commons/text/lookup/ScriptStringLookup.java
+++ b/src/main/java/org/apache/commons/text/lookup/ScriptStringLookup.java
@@ -69,7 +69,7 @@ final class ScriptStringLookup extends AbstractStringLookup {
         if (key == null) {
             return null;
         }
-        final String[] keys = key.split(SPLIT_STR);
+        final String[] keys = key.split(SPLIT_STR, 2);
         final int keyLen = keys.length;
         if (keyLen != 2) {
             throw IllegalArgumentExceptions.format("Bad script key format [%s]; expected format is DocumentPath:Key.",

--- a/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
@@ -58,4 +58,9 @@ public class ScriptStringLookupTest {
         Assertions.assertEquals("Hello World!", ScriptStringLookup.INSTANCE.lookup("javascript:\"Hello World!\""));
     }
 
+    @Test
+    public void testScriptWithColumn() {
+        Assertions.assertEquals("It Works", ScriptStringLookup.INSTANCE.lookup("javascript:true ? \"It Works\" : \"It Does Not Work\" "));
+    }
+
 }

--- a/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
@@ -60,7 +60,8 @@ public class ScriptStringLookupTest {
 
     @Test
     public void testScriptWithColumn() {
-        Assertions.assertEquals("It Works", ScriptStringLookup.INSTANCE.lookup("javascript:true ? \"It Works\" : \"It Does Not Work\" "));
+        Assertions.assertEquals("It Works",
+         ScriptStringLookup.INSTANCE.lookup("javascript:true ? \"It Works\" : \"It Does Not Work\" "));
     }
 
 }

--- a/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
@@ -59,13 +59,13 @@ public class ScriptStringLookupTest {
     }
 
     @Test
-    public void testScriptWithColumn() {
+    public void testScriptUsingMultipleColons() {
         Assertions.assertEquals("It Works",
          ScriptStringLookup.INSTANCE.lookup("javascript:true ? \"It Works\" : \"It Does Not Work\" "));
     }
 
     @Test
-    public void testNoColumn() {
+    public void testScriptMissingColon() {
         assertThrows(IllegalArgumentException.class, () -> {
             ScriptStringLookup.INSTANCE.lookup("javascript=\"test\"");
         });

--- a/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/ScriptStringLookupTest.java
@@ -64,4 +64,11 @@ public class ScriptStringLookupTest {
          ScriptStringLookup.INSTANCE.lookup("javascript:true ? \"It Works\" : \"It Does Not Work\" "));
     }
 
+    @Test
+    public void testNoColumn() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            ScriptStringLookup.INSTANCE.lookup("javascript=\"test\"");
+        });
+    }
+
 }


### PR DESCRIPTION
The usage of ":" can be pretty usefull for inside a ScriptStringLookup

 
For example ternary operations : 
`${script:javascript:'${myKey:-}' == '' ? 'Not Present' : 'Present' }`
Today it's not possible to do that because the lookup only expect one ":" 
`final String[] keys = key.split(SPLIT_STR);`

But we can limit the number of split to two:
`final String[] keys = key.split(SPLIT_STR, 2);`
 
Thanks a lot
