### PR TITLE
[TEXT-158]: empty strings must have similarity of 1, and distance of 0 (i.e. identical)

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,7 @@ The <action> type attribute can be add,update,fix,remove.
   </properties>
   <body>
   <release version="1.9.1" date="202Y-MM-DD" description="Release 1.9.1. Requires Java 8.">
+    <action issue="TEXT-158" type="fix" dev="kinow">Incorrect values for Jaccard similarity with empty strings</action>
     <action issue="TEXT-185" type="add" dev="ggregory" due-to="Larry West, Gary Gregory">Release Notes page hasn't been updated for 1.9 release yet.</action>    
     <action                  type="add" dev="ggregory" due-to="Gary Gregory">Update spotbugs.plugin.version 4.0.0 to 4.0.4.</action>    
   </release>

--- a/src/main/java/org/apache/commons/text/similarity/JaccardSimilarity.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaccardSimilarity.java
@@ -64,6 +64,9 @@ public class JaccardSimilarity implements SimilarityScore<Double> {
     private Double calculateJaccardSimilarity(final CharSequence left, final CharSequence right) {
         final int leftLength = left.length();
         final int rightLength = right.length();
+        if (leftLength == 0 && rightLength == 0) {
+            return 1d;
+        }
         if (leftLength == 0 || rightLength == 0) {
             return 0d;
         }

--- a/src/test/java/org/apache/commons/text/similarity/JaccardDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaccardDistanceTest.java
@@ -37,7 +37,7 @@ public class JaccardDistanceTest {
     @Test
     public void testGettingJaccardDistance() {
         // Expected Jaccard distance = 1.0 - (intersect / union)
-        assertEquals(1.0, classBeingTested.apply("", ""));
+        assertEquals(0.0, classBeingTested.apply("", ""));
         assertEquals(1.0, classBeingTested.apply("left", ""));
         assertEquals(1.0, classBeingTested.apply("", "right"));
         assertEquals(1.0 - (3.0 / 4), classBeingTested.apply("frog", "fog"));

--- a/src/test/java/org/apache/commons/text/similarity/JaccardSimilarityTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaccardSimilarityTest.java
@@ -37,7 +37,7 @@ public class JaccardSimilarityTest {
     @Test
     public void testGettingJaccardSimilarity() {
         // Expected Jaccard similarity = (intersect / union)
-        assertEquals(0.0, classBeingTested.apply("", ""));
+        assertEquals(1.0, classBeingTested.apply("", ""));
         assertEquals(0.0, classBeingTested.apply("left", ""));
         assertEquals(0.0, classBeingTested.apply("", "right"));
         assertEquals(3.0 / 4, classBeingTested.apply("frog", "fog"));


### PR DESCRIPTION
Now [text] will behave the same way as other libraries (Simmetrics, javastringsimilarity). Fixes the behaviour reported by other dev in https://github.com/apache/commons-text/pull/103#discussion_r263988298.

Cheers
Bruno