### PR TITLE
[TEXT-189] Fix CaseUtils when the input string contains only delimiters

### DIFF
--- a/src/main/java/org/apache/commons/text/CaseUtils.java
+++ b/src/main/java/org/apache/commons/text/CaseUtils.java
@@ -55,9 +55,12 @@ public class CaseUtils {
      * character may or may not be capitalized and it's determined by the user input for capitalizeFirstLetter
      * variable.</p>
      *
-     * <p>A {@code null} input String returns {@code null}.
+     * <p>A {@code null} input String returns {@code null}.</p>
+     *
+     * <p>A input string with only delimiter characters returns {@code ""}.</p>
+     *
      * Capitalization uses the Unicode title case, normally equivalent to
-     * upper case and cannot perform locale-sensitive mappings.</p>
+     * upper case and cannot perform locale-sensitive mappings.
      *
      * <pre>
      * CaseUtils.toCamelCase(null, false)                                 = null
@@ -67,6 +70,7 @@ public class CaseUtils {
      * CaseUtils.toCamelCase("To.Camel.Case", false, new char[]{'.'})     = "toCamelCase"
      * CaseUtils.toCamelCase(" to @ Camel case", true, new char[]{'@'})   = "ToCamelCase"
      * CaseUtils.toCamelCase(" @to @ Camel case", false, new char[]{'@'}) = "toCamelCase"
+     * CaseUtils.toCamelCase(" @", false, new char[]{'@'})                = ""
      * </pre>
      *
      * @param str  the String to be converted to camelCase, may be null
@@ -103,10 +107,8 @@ public class CaseUtils {
                 index += Character.charCount(codePoint);
             }
         }
-        if (outOffset != 0) {
-            return new String(newCodePoints, 0, outOffset);
-        }
-        return str;
+
+        return new String(newCodePoints, 0, outOffset);
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/CaseUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/CaseUtilsTest.java
@@ -44,14 +44,14 @@ public class CaseUtilsTest {
     public void testToCamelCase() {
         assertThat(CaseUtils.toCamelCase(null, false, null)).isNull();
         assertThat(CaseUtils.toCamelCase("", true, null)).isEqualTo("");
-        assertThat(CaseUtils.toCamelCase("  ", false, null)).isEqualTo("  ");
+        assertThat(CaseUtils.toCamelCase("  ", false, null)).isEqualTo("");
         assertThat(CaseUtils.toCamelCase("a  b  c  @def", false, null)).isEqualTo("aBC@def");
         assertThat(CaseUtils.toCamelCase("a b c @def", true)).isEqualTo("ABC@def");
         assertThat(CaseUtils.toCamelCase("a b c @def", true, '-')).isEqualTo("ABC@def");
         assertThat(CaseUtils.toCamelCase("a b c @def", true, '-')).isEqualTo("ABC@def");
 
         final char[] chars = {'-', '+', ' ', '@'};
-        assertThat(CaseUtils.toCamelCase("-+@ ", true, chars)).isEqualTo("-+@ ");
+        assertThat(CaseUtils.toCamelCase("-+@ ", true, chars)).isEqualTo("");
         assertThat(CaseUtils.toCamelCase("   to-CAMEL-cASE", false, chars)).isEqualTo("toCamelCase");
         assertThat(CaseUtils.toCamelCase("@@@@   to+CAMEL@cASE ", true, chars)).isEqualTo("ToCamelCase");
         assertThat(CaseUtils.toCamelCase("To+CA+ME L@cASE", true, chars)).isEqualTo("ToCaMeLCase");


### PR DESCRIPTION
Given a `str` that only contains `delimiters`, the output of `CaseUtils.toCamelCase` should be `""`, instead of the original `str`.