### PR TITLE
added cp1252 escapes

### DIFF
--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -359,7 +359,7 @@ public class StringEscapeUtils {
                     new LookupTranslator(EntityArrays.CP1252_UNESCAPE),
                     new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE),
                     new NumericEntityUnescaper()
-            )
+            );
 
     /**
      * Translator object for unescaping escaped XML.

--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -220,6 +220,20 @@ public class StringEscapeUtils {
             );
 
     /**
+     * Translator object for escaping HTML version 4.0 using CP-1252 encoding.
+     *
+     * While {@link #escapeHtml4(String)} is the expected method of use, this
+     * object allows the HTML escaping functionality to be used
+     * as the foundation for a custom translator.
+     */
+    public static final CharSequenceTranslator ESCAPE_HTML4_CP1252 =
+            new AggregateTranslator(
+                    new LookupTranslator(EntityArrays.BASIC_ESCAPE),
+                    new LookupTranslator(EntityArrays.CP1252_ESCAPE),
+                    new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE)
+            );
+
+    /**
      * Translator object for escaping individual Comma Separated Values.
      *
      * While {@link #escapeCsv(String)} is the expected method of use, this
@@ -334,6 +348,18 @@ public class StringEscapeUtils {
                     new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE),
                     new NumericEntityUnescaper()
             );
+
+    /**
+     * Translator object for unescaping escaped HTML 4.0, using the CP-1252 character
+     * with extension over ISO 8899-1 for code points 128 to 159.
+     */
+    public static final CharSequenceTranslator UNESCAPE_HTML4_CP1252 =
+            new AggregateTranslator(
+                    new LookupTranslator(EntityArrays.BASIC_UNESCAPE),
+                    new LookupTranslator(EntityArrays.CP1252_UNESCAPE),
+                    new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE),
+                    new NumericEntityUnescaper()
+            )
 
     /**
      * Translator object for unescaping escaped XML.

--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -229,6 +229,7 @@ public class StringEscapeUtils {
     public static final CharSequenceTranslator ESCAPE_HTML4_CP1252 =
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_ESCAPE),
+                    new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
                     new LookupTranslator(EntityArrays.CP1252_ESCAPE),
                     new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE)
             );
@@ -356,6 +357,7 @@ public class StringEscapeUtils {
     public static final CharSequenceTranslator UNESCAPE_HTML4_CP1252 =
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_UNESCAPE),
+                    new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
                     new LookupTranslator(EntityArrays.CP1252_UNESCAPE),
                     new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE),
                     new NumericEntityUnescaper()

--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -203,6 +203,7 @@ public class StringEscapeUtils {
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_ESCAPE),
                     new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE)
+                    new LookupTranslator(EntityArrays.CP1252_ESCAPE)
             );
 
     /**
@@ -213,20 +214,6 @@ public class StringEscapeUtils {
      * as the foundation for a custom translator.
      */
     public static final CharSequenceTranslator ESCAPE_HTML4 =
-            new AggregateTranslator(
-                    new LookupTranslator(EntityArrays.BASIC_ESCAPE),
-                    new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
-                    new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE)
-            );
-
-    /**
-     * Translator object for escaping HTML version 4.0 using CP-1252 encoding.
-     *
-     * While {@link #escapeHtml4(String)} is the expected method of use, this
-     * object allows the HTML escaping functionality to be used
-     * as the foundation for a custom translator.
-     */
-    public static final CharSequenceTranslator ESCAPE_HTML4_CP1252 =
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_ESCAPE),
                     new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
@@ -332,6 +319,7 @@ public class StringEscapeUtils {
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_UNESCAPE),
                     new LookupTranslator(EntityArrays.ISO8859_1_UNESCAPE),
+                    new LookupTranslator(EntityArrays.CP1252_UNESCAPE),
                     new NumericEntityUnescaper()
             );
 
@@ -346,23 +334,10 @@ public class StringEscapeUtils {
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_UNESCAPE),
                     new LookupTranslator(EntityArrays.ISO8859_1_UNESCAPE),
-                    new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE),
-                    new NumericEntityUnescaper()
-            );
-
-    /**
-     * Translator object for unescaping escaped HTML 4.0, using the CP-1252 character
-     * with extension over ISO 8899-1 for code points 128 to 159.
-     */
-    public static final CharSequenceTranslator UNESCAPE_HTML4_CP1252 =
-            new AggregateTranslator(
-                    new LookupTranslator(EntityArrays.BASIC_UNESCAPE),
-                    new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
                     new LookupTranslator(EntityArrays.CP1252_UNESCAPE),
                     new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE),
                     new NumericEntityUnescaper()
             );
-
     /**
      * Translator object for unescaping escaped XML.
      *

--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -202,7 +202,7 @@ public class StringEscapeUtils {
     public static final CharSequenceTranslator ESCAPE_HTML3 =
             new AggregateTranslator(
                     new LookupTranslator(EntityArrays.BASIC_ESCAPE),
-                    new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE)
+                    new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
                     new LookupTranslator(EntityArrays.CP1252_ESCAPE)
             );
 

--- a/src/main/java/org/apache/commons/text/translate/EntityArrays.java
+++ b/src/main/java/org/apache/commons/text/translate/EntityArrays.java
@@ -427,6 +427,51 @@ public class EntityArrays {
     }
 
     /**
+     * A Map&lt;CharSequence, CharSequence&gt; to escape the CP-1252 encoding. This map is a superset of
+     * <a href="https://secure.wikimedia.org/wikipedia/en/wiki/ISO/IEC_8859-1">ISO-8859-1</a> encoding, with an
+     * extension for characters with code points 128 to 159.
+     */
+    public static final Map<CharSequence, CharSequence> CP1252_ESCAPE;
+    static {
+        final Map<CharSequence, CharSequence> initialMap = new HashMap<>(ISO8859_1_ESCAPE);
+        initialMap.put("\u20AC", "&euro;");     // euro sign
+        initialMap.put("\u201A", "&sbquo;");    // german single quotes left
+        initialMap.put("\u0192", "&fnof;");     // florin sign
+        initialMap.put("\u201E", "&bdquo;");    // hungarian first level quotes left
+        initialMap.put("\u2026", "&hellip;");   // horizontal ellipsis
+        initialMap.put("\u2020", "&dagger;");   // dagger
+        initialMap.put("\u2021", "&ddagger;");  // double dagger
+        initialMap.put("\u02C6", "&circ;");     // modifier letter circumflex accent
+        initialMap.put("\u2030", "&permil;");   // per mille
+        initialMap.put("\u0160", "&Scaron;");   // LATIN CAPITAL LETTER S WITH CARON
+        initialMap.put("\u2039", "&lsaquo;");   // SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+        initialMap.put("\u0152", "&OElig;");    // LATIN CAPITAL LIGATURE OE
+        initialMap.put("\u017D", "&#x17d;");    // LATIN CAPITAL LETTER Z WITH CARON
+        initialMap.put("\u2018", "&lsquo;");    // LEFT SINGLE QUOTATION MARK
+        initialMap.put("\u2019", "&rsquo;");    // RIGHT SINGLE QUOTATION MARK
+        initialMap.put("\u201C", "&ldquo;");    // LEFT DOUBLE QUOTATION MARK
+        initialMap.put("\u201D", "&rdquo;");    // RIGHT DOUBLE QUOTATION MARK
+        initialMap.put("\u2022", "&bull;");     // BULLET
+        initialMap.put("\u2013", "&ndash;");    // EN DASH
+        initialMap.put("\u2014", "&mdash;");    // EM DASH
+        initialMap.put("\u02DC", "&tilde;");    // SMALL TILDE
+        initialMap.put("\u2122", "&trade;");    // TRADE MARK SIGN
+        initialMap.put("\u0161", "&scaron;");   // LATIN SMALL LETTER S WITH CARON
+        initialMap.put("\u0153", "&rsaquo;");   // SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+        initialMap.put("\u203A", "&oelig;");    // LATIN SMALL LIGATURE OE
+        initialMap.put("\u0178", "&Yuml;");     // LATIN CAPITAL LETTER Y WITH DIAERESIS
+        CP1252_ESCAPE = Collections.unmodifiableMap(initialMap);
+    }
+
+    /**
+     * Reverse of {@link #CP1252_ESCAPE} for unescaping purposes.
+     */
+    public static final Map<CharSequence, CharSequence> CP1252_UNESCAPE;
+    static {
+        CP1252_UNESCAPE = Collections.unmodifiableMap(invert(CP1252_ESCAPE));
+    }
+
+    /**
      * Used to invert an escape Map into an unescape Map.
      * @param map Map&lt;String, String&gt; to be inverted
      * @return Map&lt;String, String&gt; inverted array

--- a/src/main/java/org/apache/commons/text/translate/EntityArrays.java
+++ b/src/main/java/org/apache/commons/text/translate/EntityArrays.java
@@ -429,11 +429,12 @@ public class EntityArrays {
     /**
      * A Map&lt;CharSequence, CharSequence&gt; to escape the CP-1252 encoding. This map is a superset of
      * <a href="https://secure.wikimedia.org/wikipedia/en/wiki/ISO/IEC_8859-1">ISO-8859-1</a> encoding, with an
-     * extension for characters with code points 128 to 159.
+     * extension for characters with code points 128 to 159. This must be used with {@link #ISO8859_1_ESCAPE}
+     * to get all CP-1252 code points.
      */
     public static final Map<CharSequence, CharSequence> CP1252_ESCAPE;
     static {
-        final Map<CharSequence, CharSequence> initialMap = new HashMap<>(ISO8859_1_ESCAPE);
+        final Map<CharSequence, CharSequence> initialMap = new HashMap<>();
         initialMap.put("\u20AC", "&euro;");     // euro sign
         initialMap.put("\u201A", "&sbquo;");    // german single quotes left
         initialMap.put("\u0192", "&fnof;");     // florin sign

--- a/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
@@ -49,6 +49,7 @@ public class StringEscapeUtilsTest {
     private static final String FOO = "foo";
 
     private static final String[][] HTML_ESCAPES = {
+            // message, expected, original
             {"no escaping", "plain text", "plain text"},
             {"no escaping", "plain text", "plain text"},
             {"empty string", "", ""},

--- a/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
@@ -55,6 +55,7 @@ public class StringEscapeUtilsTest {
             {"null", null, null},
             {"ampersand", "bread &amp; butter", "bread & butter"},
             {"quotes", "&quot;bread&quot; &amp; butter", "\"bread\" & butter"},
+            {"smart quotes", "&ldquo;bread and circuses&rdquo;", "“bread and circuses”"},
             {"final character only", "greater than &gt;", "greater than >"},
             {"first character only", "&lt; less than", "< less than"},
             {"apostrophe", "Huntington's chorea", "Huntington's chorea"},

--- a/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
@@ -16,15 +16,7 @@
  */
 package org.apache.commons.text;
 
-import static org.apache.commons.text.StringEscapeUtils.escapeXSI;
-import static org.apache.commons.text.StringEscapeUtils.unescapeXSI;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -35,7 +27,15 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.Test;
+import static org.apache.commons.text.StringEscapeUtils.escapeXSI;
+import static org.apache.commons.text.StringEscapeUtils.unescapeXSI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for {@link StringEscapeUtils}.
@@ -56,7 +56,7 @@ public class StringEscapeUtilsTest {
             {"null", null, null},
             {"ampersand", "bread &amp; butter", "bread & butter"},
             {"quotes", "&quot;bread&quot; &amp; butter", "\"bread\" & butter"},
-            {"smart quotes", "&ldquo;bread and circuses&rdquo;", "“bread and circuses”"},
+            {"smart quotes", "&ldquo;bread and circuses&rdquo;", "\u201Cbread and circuses\u201d"},
             {"final character only", "greater than &gt;", "greater than >"},
             {"first character only", "&lt; less than", "< less than"},
             {"apostrophe", "Huntington's chorea", "Huntington's chorea"},


### PR DESCRIPTION
In EntityArrays, added escape map for CP-1252 encoding and unescape mapping. Added to StringEscapeUtils methods to escape them, ~~preserving existing ESCAPE_HTML4 functionality~~.

Functionality added in response to bug report https://issues.apache.org/jira/browse/TEXT-192.