### PR TITLE
Windows-1252 encoding for HTML numeric entities

### DIFF
--- a/src/main/java/org/apache/commons/text/translate/NumericEntityUnescaper.java
+++ b/src/main/java/org/apache/commons/text/translate/NumericEntityUnescaper.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -59,7 +60,8 @@ public class NumericEntityUnescaper extends CharSequenceTranslator {
     private final EnumSet<OPTION> options;
 
     /** Code points which are invalid Windows-1252 points. */
-    private static final Set<Integer> INVALID_POINTS = new HashSet<>(Arrays.asList(129, 141, 143, 144, 157));
+    private static final Set<Integer> INVALID_POINTS =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(129, 141, 143, 144, 157)));
 
     /**
      * Create a UnicodeUnescaper.

--- a/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
@@ -70,8 +70,7 @@ public class StringEscapeUtilsTest {
              * instead of CP-1252 points and we probably ought to prefer named entities if possible, they should not
              * be re-encoded regardless. */
             {
-                    // try a series of characters before, through, and after the cp-1252 inconsistency range
-                    // assume HTML numeric entities are encoded as cp-1252 code points
+                    // tests for all CP-1252 characters between 128 and 159, with chars 123-126 and chars 161-163
                     "cp1252",
                     "&#124;&#125;&#126;&#128;&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;" +
                             "&#142;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#158;" +


### PR DESCRIPTION
Currently, if given text like so:

```
"arma virumque cano&#133;"
"&#147;bread and circuses&#148;"
```

`StringEscapeUtils` will return the corresponding Unicode characters for points 133, 147, and 148, which are bunch of obscure basically-never-used control characters that display as spaces. Those characters are, however, used more often in [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) encoding corresponding to characters like € and ™.

I've changed `NumericEntityUnescaper` treat valid CP-1252 code points between 128 and 159 (inclusive) as CP-1252 characters and decodes them to the corresponding punctuation etc marks instead of the obscure Unicode control characters.