### PR TITLE
[TEXT-191] Fixed JaroWinklerDistance returns the same values as JaroWinklerSimilarity

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action issue="TEXT-187" type="fix" dev="kinow">Add GraalVM test dependencies to fix test failures with Java 15.</action>
     <action issue="TEXT-158" type="fix" dev="kinow">Incorrect values for Jaccard similarity with empty strings.</action>
     <action issue="TEXT-186" type="fix" dev="ggregory" due-to="Gautam Korlam, Gary Gregory">StringSubstitutor map constructor throws NPE on 1.9 with null map.</action>
+    <action issue="TEXT-191" type="fix" dev="kinow" due-to="Bradley David Rumball">JaroWinklerDistance returns the same values as JaroWinklerSimilarity.</action>
     <!-- ADD -->
     <action issue="TEXT-190" type="add" dev="kinow" due-to="Benjamin Bing">Document negative limit for WordUtils abbreviate method</action>
     <action issue="TEXT-188" type="add" dev="kinow" due-to="Jakob Vesterstrøm">Speed up LevenshteinDistance with threshold by exiting early</action>

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
@@ -33,6 +33,11 @@ public class JaroWinklerDistance implements EditDistance<Double> {
     public static final int INDEX_NOT_FOUND = -1;
 
     /**
+     * Jaro Winkler similarity object used to calculate the distance (1 - similarity).
+     */
+    private final JaroWinklerSimilarity similarity = new JaroWinklerSimilarity();
+
+    /**
      * Computes the Jaro Winkler Distance between two character sequences.
      *
      * <pre>
@@ -71,20 +76,7 @@ public class JaroWinklerDistance implements EditDistance<Double> {
             throw new IllegalArgumentException("CharSequences must not be null");
         }
 
-        // TODO: replace the rest of the code by this in 2.0, see TEXT-104
-        //
-        // JaroWinklerSimilarity similarity = new JaroWinklerSimilarity();
-        // return 1 - similarity.apply(left, right);
-
-        final double defaultScalingFactor = 0.1;
-        final int[] mtp = matches(left, right);
-        final double m = mtp[0];
-        if (m == 0) {
-            return 1D;
-        }
-        final double j = ((m / left.length() + m / right.length() + (m - (double) mtp[1] / 2) / m)) / 3;
-        final double jw = j < 0.7D ? j : j + defaultScalingFactor * mtp[2] * (1D - j);
-        return 1 - jw;
+        return 1 - similarity.apply(left, right);
     }
 
     // TODO: remove this method in 2.0, see TEXT-104

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
@@ -84,7 +84,7 @@ public class JaroWinklerDistance implements EditDistance<Double> {
         }
         final double j = ((m / left.length() + m / right.length() + (m - (double) mtp[1] / 2) / m)) / 3;
         final double jw = j < 0.7D ? j : j + defaultScalingFactor * mtp[2] * (1D - j);
-        return 1-jw;
+        return 1 - jw;
     }
 
     // TODO: remove this method in 2.0, see TEXT-104

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerDistance.java
@@ -80,11 +80,11 @@ public class JaroWinklerDistance implements EditDistance<Double> {
         final int[] mtp = matches(left, right);
         final double m = mtp[0];
         if (m == 0) {
-            return 0D;
+            return 1D;
         }
         final double j = ((m / left.length() + m / right.length() + (m - (double) mtp[1] / 2) / m)) / 3;
         final double jw = j < 0.7D ? j : j + defaultScalingFactor * mtp[2] * (1D - j);
-        return jw;
+        return 1-jw;
     }
 
     // TODO: remove this method in 2.0, see TEXT-104

--- a/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
@@ -46,24 +46,12 @@ public class JaroWinklerDistanceTest {
         assertEquals(0.028572d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
         assertEquals(0.058334d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
         assertEquals(0.088889d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
-        // TODO: replace tests in 2.0. See TEXT-104 for more.
-        // assertEquals(0d, distance.apply("", ""), 0.00001d);
-        // assertEquals(0d, distance.apply("foo", "foo"), 0.00001d);
-        // assertEquals(1 - 0.94166d, distance.apply("foo", "foo "), 0.00001d);
-        // assertEquals(1 - 0.90666d, distance.apply("foo", "foo  "), 0.00001d);
-        // assertEquals(1 - 0.86666d, distance.apply("foo", " foo "), 0.00001d);
-        // assertEquals(1 - 0.51111d, distance.apply("foo", "  foo"), 0.00001d);
-        // assertEquals(1 - 0.92499d, distance.apply("frog", "fog"), 0.00001d);
-        // assertEquals(1.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
-        // assertEquals(1 - 0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
-        // assertEquals(1 - 0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
-        // assertEquals(1 - 0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
-        // assertEquals(1 - 0.942d,
-        //         distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
-        // assertEquals(1 - 0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
-        // assertEquals(1 - 0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
-        // assertEquals(1 - 0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
-        // assertEquals(1 - 0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
+        assertEquals(0d, distance.apply("", ""), 0.00001d);
+        assertEquals(0d, distance.apply("foo", "foo"), 0.00001d);
+        assertEquals(1 - 0.94166d, distance.apply("foo", "foo "), 0.00001d);
+        assertEquals(1 - 0.90666d, distance.apply("foo", "foo  "), 0.00001d);
+        assertEquals(1 - 0.86666d, distance.apply("foo", " foo "), 0.00001d);
+        assertEquals(1 - 0.51111d, distance.apply("foo", "  foo"), 0.00001d);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/JaroWinklerDistanceTest.java
@@ -36,16 +36,16 @@ public class JaroWinklerDistanceTest {
 
     @Test
     public void testGetJaroWinklerDistance_StringString() {
-        assertEquals(0.92499d, distance.apply("frog", "fog"), 0.00001d);
-        assertEquals(0.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
-        assertEquals(0.44166d, distance.apply("elephant", "hippo"), 0.00001d);
-        assertEquals(0.90666d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
-        assertEquals(0.95251d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
-        assertEquals(0.942d, distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
-        assertEquals(0.898018d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
-        assertEquals(0.971428d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
-        assertEquals(0.941666d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
-        assertEquals(0.911111d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
+        assertEquals(0.07501d, distance.apply("frog", "fog"), 0.00001d);
+        assertEquals(1.0d, distance.apply("fly", "ant"), 0.00000000000000000001d);
+        assertEquals(0.55834d, distance.apply("elephant", "hippo"), 0.00001d);
+        assertEquals(0.09334d, distance.apply("ABC Corporation", "ABC Corp"), 0.00001d);
+        assertEquals(0.04749d, distance.apply("D N H Enterprises Inc", "D & H Enterprises, Inc."), 0.00001d);
+        assertEquals(0.058d, distance.apply("My Gym Children's Fitness Center", "My Gym. Childrens Fitness"), 0.00001d);
+        assertEquals(0.101982d, distance.apply("PENNSYLVANIA", "PENNCISYLVNIA"), 0.00001d);
+        assertEquals(0.028572d, distance.apply("/opt/software1", "/opt/software2"), 0.00001d);
+        assertEquals(0.058334d, distance.apply("aaabcd", "aaacdb"), 0.00001d);
+        assertEquals(0.088889d, distance.apply("John Horn", "John Hopkins"), 0.00001d);
         // TODO: replace tests in 2.0. See TEXT-104 for more.
         // assertEquals(0d, distance.apply("", ""), 0.00001d);
         // assertEquals(0d, distance.apply("foo", "foo"), 0.00001d);


### PR DESCRIPTION
Fixed JaroWinklerDistance to be in line with Javadoc and expected output.

JaroWinklerDistance was returning incorrectly with the same values as the JaroWinklerSimilarity class.

JaroWinklerDistance was updated to return the correct 1- value, and tests maintained.