### PR TITLE
Update actions/setup-java to v2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,8 +39,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v2
       with:
+        distribution: adopt
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: mvn -V apache-rat:check spotbugs:check javadoc:javadoc -Ddoclint=all package --file pom.xml --no-transfer-progress

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,7 +62,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump junit-jupiter from 5.6.2 to 5.7.1 #163 #204.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump assertj-core from 3.16.1 to 3.19.0 #151 #157 #160 #178 #184 #199.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump commons-io from 2.7 to 2.8.0 #161.</action>
-    <action                  type="update" dev="kinow" due-to="Dependabot">Bump actions/setup-java from v1.4.0 to v1.4.3 #147 #156 #155 #172.</action>
+    <action                  type="update" dev="kinow" due-to="Dependabot">Bump actions/setup-java from v1.4.0 to v1.4.3 #147 #156 #155 #172 #215.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump commons-parent from 51 to 52 #145.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump actions/checkout from v1 to v2.3.4 #138 #146 #165 #183.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump maven-pmd-plugin from 3.13.0 to 3.14.0 #186.</action>


### PR DESCRIPTION
Dependabot's PR #212 doesn't have the `distribution` arg, and I couldn't figure out a way to update the dependabot branch :cry: 