### PR TITLE
TEXT-211 - TextStringBuilder.equals whatever the capacity is

### DIFF
--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -1850,7 +1850,14 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @return true if the builders contain the same characters in the same order
      */
     public boolean equals(final TextStringBuilder other) {
-        return other != null && Arrays.equals(buffer, other.buffer);
+    	
+    	if(other == null) {
+    		return false;
+    	}
+    	if (this.size != other.size) {
+            return false;
+        }
+        return Arrays.equals(ArrayUtils.subarray(buffer, 0, size), ArrayUtils.subarray(other.buffer, 0, size));
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
@@ -900,8 +900,8 @@ public class TextStringBuilderTest {
 
     @Test
     public void testEquals() {
-        final TextStringBuilder sb1 = new TextStringBuilder();
-        final TextStringBuilder sb2 = new TextStringBuilder();
+        final TextStringBuilder sb1 = new TextStringBuilder(50);
+        final TextStringBuilder sb2 = new TextStringBuilder(100);
         assertTrue(sb1.equals(sb2));
         assertTrue(sb1.equals(sb1));
         assertTrue(sb2.equals(sb2));


### PR DESCRIPTION
Used subarrays for Arrays.equals to allow equals method to be relevant in case the 2 TextStringBuilders have not the same capacity.

Updated the test case to reflect the change