### PR TITLE
apostrophes, typos and clarifications

### DIFF
--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -136,7 +136,7 @@ import org.apache.commons.text.matcher.StringMatcherFactory;
  *
  * <h2>Using Interpolation</h2>
  * <p>
- * The default interpolator let's you use string lookups like:
+ * The default interpolator lets you use string lookups like:
  * </p>
  *
  * <pre>
@@ -558,7 +558,7 @@ public class StringSubstitutor {
     /**
      * Creates a new instance based on the given StringSubstitutor.
      *
-     * @param other The StringSubstitutor is use as the source.
+     * @param other The StringSubstitutor used as the source.
      * @since 1.9
      */
     public StringSubstitutor(final StringSubstitutor other) {
@@ -1316,7 +1316,7 @@ public class StringSubstitutor {
      * @param length the length within the builder to be processed, must be valid
      * @param priorVariables the stack keeping track of the replaced variables, may be null
      * @return The result.
-     * @throws IllegalArgumentException if variable is not found when its allowed to throw exception
+     * @throws IllegalArgumentException if variable is not found and <pre>isEnableUndefinedVariableException()==true</pre>
      * @since 1.9
      */
     private Result substitute(final TextStringBuilder builder, final int offset, final int length,

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -61,7 +61,7 @@ limitations under the License.
         or future standard Java classes.
       </p>
 
-      <p>Beyond the text utilities ported over from lang, we have also included various
+      <p>Beyond the text utilities ported over from Commons Lang, we have also included various
         string similarity and distance functions. Lastly, there are also utilities for
         addressing differences between bodies of text for the sake of viewing these
         differences.
@@ -69,7 +69,7 @@ limitations under the License.
 
       <subsection name="StringEscapeUtils">
         <p>From Lang 3.5, we have moved into Text StringEscapeUtils and StrTokenizer.
-          It's provides ways in which to generate pieces of text, such as might
+          It provides ways in which to generate pieces of text, such as might
           be used for default passwords. StringEscapeUtils contains methods to
           escape and unescape Java, JavaScript, HTML and XML. It is worth noting that
           the package <code>org.apache.commons.text.translate</code> holds the
@@ -223,7 +223,7 @@ final String text = interpolator.replace(
 
       <p>The algorithms that implement the EditDistance interface follow the
         same
-        simple principle: the more similar (closer) strings are, lower is the
+        simple principle: the more similar (closer) strings are, the lower is the
         distance.
         For example, the words house and hose are closer than house and
         trousers.


### PR DESCRIPTION
Just read the docs for first time and found a few apostrophe mistakes  and  added 1 clarification to make Javadoc more precise.