### PR TITLE
(doc) update definition of upper in abbreviate method to match behavior

### DIFF
--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -51,8 +51,7 @@ public class WordUtils {
      *                    If the empty String is passed, the empty string is returned.
      * @param lower       the lower limit; negative value is treated as zero.
      * @param upper       the upper limit; specify -1 if no limit is desired.
-     *                    If the upper limit is lower than the lower limit, it will be
-     *                    adjusted to be the same as the lower limit.
+     *                    The upper limit cannot be lower than the lower limit.
      * @param appendToEnd String to be appended to the end of the abbreviated string.
      *                    This is appended ONLY if the string was indeed abbreviated.
      *                    The append does not count towards the lower or upper limits.


### PR DESCRIPTION
Looks like the documentation doesn't match the actual behavior of the abbreviate method. We should update the method or the docs to match. (see line 81 of WordUtils.java).

The docs specify that "If the upper limit is lower than the lower limit, it will be adjusted to be the same as the lower limit." but the actual behavior forbids the upper limit from being lower than the lower limit.