### PR TITLE
TEXT-215: Prevent decimal numeric entities from wrongly including hexadecimal characters

### DIFF
--- a/src/main/java/org/apache/commons/text/translate/NumericEntityUnescaper.java
+++ b/src/main/java/org/apache/commons/text/translate/NumericEntityUnescaper.java
@@ -115,8 +115,8 @@ public class NumericEntityUnescaper extends CharSequenceTranslator {
             int end = start;
             // Note that this supports character codes without a ; on the end
             while (end < seqEnd && (input.charAt(end) >= '0' && input.charAt(end) <= '9'
-                                    || input.charAt(end) >= 'a' && input.charAt(end) <= 'f'
-                                    || input.charAt(end) >= 'A' && input.charAt(end) <= 'F')) {
+                                    || isHex && (input.charAt(end) >= 'a' && input.charAt(end) <= 'f'
+                                    || input.charAt(end) >= 'A' && input.charAt(end) <= 'F'))) {
                 end++;
             }
 


### PR DESCRIPTION
Hello,
This a quick bugfix on the NumericEntityUnescaper. The bug allows decimal characters entities without semi-colon and followed by a letter from A to E to be ignored by the translator.
A full description of the problem is found in the ticket: https://issues.apache.org/jira/browse/TEXT-215