### PR TITLE
(doc) Add missing exception javadocs, add a couple more unit tests

### DIFF
--- a/src/main/java/org/apache/commons/text/FormattableUtils.java
+++ b/src/main/java/org/apache/commons/text/FormattableUtils.java
@@ -86,6 +86,8 @@ public class FormattableUtils {
      * @param ellipsis  the ellipsis to use when precision dictates truncation, null or
      *  empty causes a hard truncation
      * @return The {@code formatter} instance, not null
+     * @throws IllegalArgumentException if {@code ellipsis.length() > precision},
+     *  given that {@code ellipsis} is not null and {@code precision >= 0}
      */
     public static Formatter append(final CharSequence seq, final Formatter formatter, final int flags, final int width,
             final int precision, final char padChar, final CharSequence ellipsis) {
@@ -125,6 +127,8 @@ public class FormattableUtils {
      * @param ellipsis  the ellipsis to use when precision dictates truncation, null or
      *  empty causes a hard truncation
      * @return The {@code formatter} instance, not null
+     * @throws IllegalArgumentException if {@code ellipsis.length() > precision},
+     *  given that {@code ellipsis} is not null and {@code precision >= 0}
      */
     public static Formatter append(final CharSequence seq, final Formatter formatter, final int flags, final int width,
             final int precision, final CharSequence ellipsis) {

--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -734,6 +734,10 @@ public class StringSubstitutor {
      * @param length the length within the array to be processed, must be valid
      * @return The result of the replace operation
      * @throws IllegalArgumentException if variable is not found when its allowed to throw exception
+     * @throws StringIndexOutOfBoundsException if {@code offset} is not in the
+     *  range {@code 0 <= offset <= chars.length}
+     * @throws StringIndexOutOfBoundsException if {@code length < 0}
+     * @throws StringIndexOutOfBoundsException if {@code offset + length > chars.length}
      */
     public String replace(final char[] source, final int offset, final int length) {
         if (source == null) {
@@ -831,6 +835,10 @@ public class StringSubstitutor {
      * @param length the length within the source to be processed, must be valid
      * @return The result of the replace operation
      * @throws IllegalArgumentException if variable is not found when its allowed to throw exception
+     * @throws StringIndexOutOfBoundsException if {@code offset} is not in the
+     *  range {@code 0 <= offset <= source.length()}
+     * @throws StringIndexOutOfBoundsException if {@code length < 0}
+     * @throws StringIndexOutOfBoundsException if {@code offset + length > source.length()}
      */
     public String replace(final String source, final int offset, final int length) {
         if (source == null) {

--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -440,6 +440,10 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @param startIndex the start index, inclusive, must be valid
      * @param length the length to append, must be valid
      * @return this, to enable chaining
+     * @throws StringIndexOutOfBoundsException if {@code startIndex} is not in the
+     *  range {@code 0 <= startIndex <= chars.length}
+     * @throws StringIndexOutOfBoundsException if {@code length < 0}
+     * @throws StringIndexOutOfBoundsException if {@code startIndex + length > chars.length}
      */
     public TextStringBuilder append(final char[] chars, final int startIndex, final int length) {
         if (chars == null) {
@@ -621,6 +625,10 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @param startIndex the start index, inclusive, must be valid
      * @param length the length to append, must be valid
      * @return this, to enable chaining
+     * @throws StringIndexOutOfBoundsException if {@code startIndex} is not in the
+     *  range {@code 0 <= startIndex <= str.length()}
+     * @throws StringIndexOutOfBoundsException if {@code length < 0}
+     * @throws StringIndexOutOfBoundsException if {@code startIndex + length > str.length()}
      */
     public TextStringBuilder append(final String str, final int startIndex, final int length) {
         if (str == null) {

--- a/src/main/java/org/apache/commons/text/translate/SinglePassTranslator.java
+++ b/src/main/java/org/apache/commons/text/translate/SinglePassTranslator.java
@@ -35,6 +35,10 @@ abstract class SinglePassTranslator extends CharSequenceTranslator {
         return clazz.isAnonymousClass() ?  clazz.getName() : clazz.getSimpleName();
     }
 
+    /**
+     * {@inheritDoc}
+     * @throws IllegalArgumentException if {@code index != 0}
+     */
     @Override
     public int translate(final CharSequence input, final int index, final Writer writer) throws IOException {
         if (index != 0) {

--- a/src/test/java/org/apache/commons/text/FormattableUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/FormattableUtilsTest.java
@@ -161,6 +161,14 @@ public class FormattableUtilsTest {
     }
 
     @Test
+    public void testIllegalEllipsisWith7Args() {
+        String ellipsis = "xxxx";
+        int precisionLessThanEllipsisLength = ellipsis.length() - 1;
+        assertThatIllegalArgumentException().isThrownBy(() -> FormattableUtils.append("foo", createFormatter(), 0, 0,
+                precisionLessThanEllipsisLength, '}', ellipsis));
+    }
+
+    @Test
     public void testPublicConstructorExists() {
         new FormattableUtils();
     }

--- a/src/test/java/org/apache/commons/text/StringSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/text/StringSubstitutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.text;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1083,6 +1084,28 @@ public class StringSubstitutorTest {
         sub.setPreserveEscapes(true);
         assertTrue(sub.isPreserveEscapes());
         assertEqualsCharSeq("value $${escaped}", replace(sub, org));
+    }
+
+    @Test
+    public void testReplaceThrowsStringIndexOutOfBoundsException() {
+        final StringSubstitutor sub = new StringSubstitutor();
+
+        // replace(char[], int, int)
+        final char[] emptyCharArray = new char[] {};
+        // offset greater than array length
+        assertThatExceptionOfType(StringIndexOutOfBoundsException.class).isThrownBy(
+                () -> sub.replace(emptyCharArray, 0, 1));
+        // source != null && (offset > source.length || offset < 0)
+        assertThatExceptionOfType(StringIndexOutOfBoundsException.class).isThrownBy(
+                () -> sub.replace(emptyCharArray, 1, 0));
+
+        // replace(String, int, int)
+        // offset greater than source length
+        assertThatExceptionOfType(StringIndexOutOfBoundsException.class).isThrownBy(
+                () -> sub.replace("", 1, 1));
+        // source != null && offset >= 0 && offset <= source.length() && (length > -offset + source.length() || length < 0)
+        assertThatExceptionOfType(StringIndexOutOfBoundsException.class).isThrownBy(
+                () -> sub.replace("", 0, 1));
     }
 
 }


### PR DESCRIPTION
Hello! I found a few methods that could throw exceptions that were not documented in javadoc.
I added the documentation and tests when applicable.
Those that throw `StringIndexOutOfBoundsException` are quite tricky to express concisely, so I'm happy to change them if you suggest something else.

By the way, I'm working on a tool that can identify exceptions that could be thrown in given methods.
It can help identify missing documentation and provide some inputs to be used in tests.
I could submit more pull requests if the project welcomes this kind of contribution.