### PR TITLE
[TEXT-209]Fixed LookupTranslator returns count of codepoints consumed

### DIFF
--- a/src/main/java/org/apache/commons/text/translate/LookupTranslator.java
+++ b/src/main/java/org/apache/commons/text/translate/LookupTranslator.java
@@ -95,7 +95,7 @@ public class LookupTranslator extends CharSequenceTranslator {
 
                 if (result != null) {
                     writer.write(result);
-                    return i;
+                    return Character.codePointCount(subSeq, 0, subSeq.length());
                 }
             }
         }

--- a/src/test/java/org/apache/commons/text/translate/LookupTranslatorTest.java
+++ b/src/test/java/org/apache/commons/text/translate/LookupTranslatorTest.java
@@ -61,4 +61,17 @@ public class LookupTranslatorTest  {
         assertThatExceptionOfType(InvalidParameterException.class).isThrownBy(() -> new LookupTranslator(null));
     }
 
+    @Test
+    public void testTranslateSupplementaryCharacter() {
+        /* Key: string with Mathematical double-struck capital A (U+1D538) */
+        String symbol = new StringBuilder().appendCodePoint(0x1D538).toString();
+        /* Map U+1D538 to "A" */
+        Map<CharSequence, CharSequence> map = new HashMap<>();
+        map.put(symbol, "A");
+        LookupTranslator translator = new LookupTranslator(map);
+        String translated = translator.translate(symbol + "=A");
+        /* we should get "A=A". */
+        assertThat(translated).as("Incorrect value").isEqualTo("A=A");
+    }
+
 }


### PR DESCRIPTION
Hello,
This a quick bugfix on the LookupTranslator. The bug returns count of chars consumed, not of codepoints consumed.
A full description of the problem is found in the ticket: https://issues.apache.org/jira/browse/TEXT-209