### PR TITLE
Revert #327 change (checkstyle 9.3 to 10.2) due to JVM incompatibility. Fix GH Actions to run checkstyle.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,4 +42,4 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -V apache-rat:check spotbugs:check javadoc:javadoc -Ddoclint=all package --file pom.xml --no-transfer-progress
+      run: mvn

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <commons.scmPubCheckoutDirectory>site-content</commons.scmPubCheckoutDirectory>
 
     <checkstyle.plugin.version>3.1.2</checkstyle.plugin.version>
-    <checkstyle.version>10.2</checkstyle.version>
+    <checkstyle.version>9.3</checkstyle.version>
 
     <commons.spotbugs.plugin.version>4.7.0.0</commons.spotbugs.plugin.version>
     <commons.spotbugs.impl.version>4.7.0</commons.spotbugs.impl.version>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -79,7 +79,7 @@ The <action> type attribute can be add,update,fix,remove.
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump actions/checkout from v1 to 3 #138, #146, #165, #183, #274, #279, #304.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump actions/cache from v2 to v2.1.6 #205 #217 #234.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump github/codeql-action from 1 to 2 #319.</action>
-    <action                  type="update" dev="ggregory" due-to="Dependabot">Bump checkstyle from 8.34 to 10.2, #141, #168, #182, #188, #193, #201, #208, #211, #228, #235, #245, #253, #255, #262, #270, #280, #287, #299, #315, #321, #327.</action>
+    <action                  type="update" dev="ggregory" due-to="Dependabot">Bump checkstyle from 8.34 to 9.3, #141, #168, #182, #188, #193, #201, #208, #211, #228, #235, #245, #253, #255, #262, #270, #280, #287, #299, #315, #321.</action>
     <action                  type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">Bump spotbugs-maven-plugin from 4.0.0 to 4.7.0.0, #144, #150, #167, #176, #194, #210, #223, #250, #268, #273, #277, #278, #286, #293, #303, #320, #325.</action>
     <action                  type="update" dev="ggregory" due-to="Dependabot">Bump mockito-inline from 3.4.4 to 4.5.1, #143, #148, #149, #152, #153, #154, #158, #159, #166, #177, #180, #187, #195, #197, #207, #216, #231, #236, #237, #243, #258, #259, #260, #261, #272, #285, #291, #305, #317.</action>
     <action                  type="update" dev="kinow" due-to="Dependabot">Bump junit-jupiter from 5.6.2 to 5.8.2 #163, #204, #232, #265, #269, #288.</action>


### PR DESCRIPTION
@garydgregory reverting that checkstyle change and using the default build target instead of specifying what to run on GH Actions.