### PR TITLE
Add statement about CVE-2022-42889 to frontpage

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -41,6 +41,41 @@ The <a href="scm.html">Git repository</a> can be
 </p>
 </section>
 <!-- ================================================== -->
+<section name="Security">
+  <subsection name="CVE-2022-42889 prior to 1.10.0, RCE when applied to untrusted input">
+    <p>
+    On 2022-10-13, the Apache Commons Text team disclosed <a href="https://www.cve.org/CVERecord?id=CVE-2022-42889">CVE-2022-42889</a>. Key takeaways:
+    <ul>
+      <li>If you rely on software that uses a version of commons-text prior to 1.10.0, you are likely still not vulnerable: only if this software uses the <code>StringSubstitutor</code> API without properly sanitizing any untrusted input.</li>
+      <li>If your own software uses commons-text, double-check whether it uses the <code>StringSubstitutor</code> API without properly sanitizing any untrusted input. If so, an update to 1.10.0 could be a quick workaround, but the recommended solution is to also properly validate and sanitize any untrusted input.</li>
+    </ul>
+    </p>
+    <p>
+    Apache Commons Text is a low-level library for performing various text operations, such as escaping, calculating string differences, and substituting placeholders in the text with values looked up through interpolators. When using the string substitution feature, some of the available interpolators can trigger network access or code execution. This is intended, but it also means an application that includes user input in the string passed to the substitution without properly sanitizing it would allow an attacker to trigger those interpolators.
+    </p>
+    <p>For that reason the Apache Commons Text team have decided to update the configuration to be more "secure by default", so that the impact of a failure to validate inputs is mitigated and will not give an attacker access to these interpolators. However, it is still recommended that users treat untrusted input with care.
+    </p>
+    <p>
+    We're not currently aware of any applications that pass untrusted input to the substitutor and thus would have been impacted by this problem prior to Apache Commons Text 1.10.0.
+    </p>
+    <p>
+    This issue is different from <a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.15.0">Log4Shell (CVE-2021-44228)</a> because in Log4Shell, string interpolation was possible from the log message body, which commonly contains untrusted input. In the Apache Common Text issue, the relevant method is explicitly intended and clearly documented to perform string interpolation, so it is much less likely that applications would inadvertently pass in untrusted input without proper validation.
+    </p>
+    <p>
+    Credit: this issue was reported independently by Ruilin and by <a href="https://github.com/pwntester">@pwntester (Alvaro Muñoz)</a> of the <a href="https://securitylab.github.com">GitHub Security Lab team</a>. Thank you!
+    </p>
+    <p>
+    References:
+    <ul>
+    <li><a href="https://lists.apache.org/thread/n2bd4vdsgkqh2tm14l1wyc3jyol7s1om">Announcement on dev@commons.apache.org</a></li>
+    <li><a href="https://www.openwall.com/lists/oss-security/2022/10/13/4">Announcement on oss-security</a></li>
+    <li><a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889">Advisory on cve.org</a></li>
+    <li><a href="https://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/">GHSL advisory</a></li>
+    </ul>
+    </p>
+  </subsection>
+</section>
+<!-- ================================================== -->
 <section name="Release Information">
 <p>
   Download the latest release from dependency-info.html</p>


### PR DESCRIPTION
To put things into perspective since this is currently getting some attention.

Can be moved to the 'security' page later.

![commons-text](https://user-images.githubusercontent.com/131856/196435661-a0fe846d-805f-411a-84f8-6602e2b65754.png)
