### PR TITLE
Fix javadoc for escapeHtml4

### DIFF
--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -567,7 +567,7 @@ public class StringEscapeUtils {
      * <p>{@code "bread" &amp; "butter"}</p>
      * becomes:
      * <p>
-     * {@code &amp;quot;bread&amp;quot; &amp;amp; &amp;quot;butter&amp;quot;}.
+     * {@code &quot;bread&quot; &amp;amp; &quot;butter&quot;}.
      * </p>
      *
      * <p>Supports all known HTML 4.0 entities, including funky accents.


### PR DESCRIPTION
the javadoc example for the code was wrongly escaping quotes

as a result of an incorret conversion in https://github.com/apache/commons-text/commit/0dfe9634a4578090b3b5b670ab2fe80acfa8f280 

```
jshell> org.apache.commons.text.StringEscapeUtils.escapeHtml4("\"bread\" &amp; \"butter\"")
$1 ==> "&quot;bread&quot; &amp;amp; &quot;butter&quot;"
```
