### PR TITLE
Rollback TextStringBuidler#hashCode implementation to 1.8 release

### DIFF
--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -1964,7 +1964,12 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     @Override
     public int hashCode() {
-        return this.toString().hashCode();
+        final char[] buf = buffer;
+        int hash = 0;
+        for (int i = size - 1; i >= 0; i--) {
+            hash = 31 * hash + buf[i];
+        }
+        return hash;
     }
 
     /**


### PR DESCRIPTION
The implementation that was done in the scope of the PR #281 introduced higher rate of garbage collections because of additional allocations of String object. So I returned the code to the logic it had in the 1.8 release.

In order to test higher GC rate I created a simple loop and turned on GC logging (-verbose:gc -XX:+PrintGCDetails):
```
var builder = new TextStringBuilder("<SOME TEXT>");
for (int i = 0; i < 100_000_000; i++) {
  builder.hashCode();
}
```

And the run with 1.10 had 55 GC collections instead of two ones in 1.8.