### PR TITLE
TEXT-227: removed unnecessary IF statement

### DIFF
--- a/src/main/java/org/apache/commons/text/AlphabetConverter.java
+++ b/src/main/java/org/apache/commons/text/AlphabetConverter.java
@@ -87,9 +87,6 @@ public final class AlphabetConverter {
      * @see "http://www.oracle.com/us/technologies/java/supplementary-142654.html"
      */
     private static String codePointToString(final int i) {
-        if (Character.charCount(i) == 1) {
-            return String.valueOf((char) i);
-        }
         return new String(Character.toChars(i));
     }
 


### PR DESCRIPTION
[TEXT-227](https://issues.apache.org/jira/browse/TEXT-227) removed unnecessary IF statement, because the Character.toChars(i) can handle both single and double-width characters