### PR TITLE
Cases API + 4 implementations (Pascal, Camel, Kebab, Snake)

### DIFF
--- a/src/main/java/org/apache/commons/text/cases/CamelCase.java
+++ b/src/main/java/org/apache/commons/text/cases/CamelCase.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.CharUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Case implementation that parses and formats strings of the form 'myCamelCase'
+ * <p>
+ * This case separates tokens on uppercase ascii alpha characters, with the exception
+ * that the first token begin with a lowercase ascii alpha character.
+ * </p>
+ */
+public class CamelCase implements Case {
+
+    /** constant reuseable instance of this case. */
+    public static final CamelCase INSTANCE = new CamelCase();
+
+    /**
+     * Constructs new CamelCase instance.
+     */
+    public CamelCase() {
+        super();
+    }
+
+    /**
+     * Parses string tokens from a Camel Case formatted string.
+     * <p>
+     * Parses each character of the string parameter and creates new tokens when uppercase ascii
+     * letters are encountered. The upppercase letter is considered part of the new token. The very
+     * first character of the string is an exception to this rule and must be a lowercase ascii
+     * character. This method places no other restrictions on the content of the string. <br>
+     * Note: This method should never produce empty tokens.
+     * </p>
+     * @param string Camel Case formatted string to parse
+     * @return list of tokens parsed from the string
+     */
+    @Override
+    public List<String> parse(String string) {
+        List<String> tokens = new LinkedList<>();
+        if (string.length() == 0) {
+            return tokens;
+        }
+        if (!CharUtils.isAsciiAlphaLower(string.charAt(0))) {
+            throw new IllegalArgumentException("Character '" + string.charAt(0) + "' at index 0 must be an ascii lowercase letter");
+        }
+        /*StringBuilder tokenBuilder = new StringBuilder();
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (CharUtils.isAsciiAlphaUpper(c)) {
+                tokens.add(tokenBuilder.toString());
+                tokenBuilder.setLength(0);
+            }
+            tokenBuilder.append(c);
+        }
+        tokens.add(tokenBuilder.toString());*/
+        int strLen = string.length();
+        int[] tokenCodePoints = new int[strLen];
+        int tokenCodePointsOffset = 0;
+        for (int i = 0; i < string.length();) {
+            final int codePoint = string.codePointAt(i);
+            if (CharUtils.isAsciiAlphaUpper((char) codePoint)) {
+                if (tokenCodePointsOffset > 0) {
+                    tokens.add(new String(tokenCodePoints, 0, tokenCodePointsOffset));
+                    tokenCodePoints = new int[strLen];
+                    tokenCodePointsOffset = 0;
+                }
+                tokenCodePoints[tokenCodePointsOffset++] = codePoint;
+                i += Character.charCount(codePoint);
+            } else {
+                tokenCodePoints[tokenCodePointsOffset++] = codePoint;
+                i += Character.charCount(codePoint);
+            }
+        }
+        tokens.add(new String(tokenCodePoints, 0, tokenCodePointsOffset));
+        return tokens;
+    }
+
+    /**
+     * Formats tokens into a Camel Case string.
+     * <p>
+     * Iterates each token and creates a camel case formatted string. Each token must begin with an
+     * ascii letter, which will be forced uppercase in the output, except for the very first token,
+     * which will have a lowercase first character. The remaining characters in all tokens will be
+     * forced lowercase. This Case does not support empty tokens.<br>
+     * No other restrictions are placed on token contents.
+     * </p>
+     * @param tokens String tokens to format into CamelCase
+     * @return Camel Case formatted string
+     */
+    @Override
+    public String format(Iterable<String> tokens) {
+        StringBuilder formattedString = new StringBuilder();
+        int i = 0;
+        for (String token : tokens) {
+            if (token.length() == 0) {
+                throw new IllegalArgumentException("Unsupported empty token at index " + i);
+            }
+            if (!CharUtils.isAsciiAlpha(token.charAt(0))) {
+                throw new IllegalArgumentException("First character '" + token.charAt(0) + "' in token " + i + " must be an ascii letter");
+            }
+            String formattedToken = (i == 0 ? token.substring(0, 1).toLowerCase() : token.substring(0, 1).toUpperCase())
+                    + (token.length() > 1 ? token.substring(1).toLowerCase() : StringUtils.EMPTY);
+            i++;
+            formattedString.append(formattedToken);
+        }
+        return formattedString.toString();
+    }
+
+}

--- a/src/main/java/org/apache/commons/text/cases/Case.java
+++ b/src/main/java/org/apache/commons/text/cases/Case.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+import java.util.List;
+
+/**
+ * Handles formatting and parsing tokens to/from a String. For most implementations tokens returned
+ * by the parse method should abide by any restrictions present in the format method. i.e. Calling
+ * format() with the results of a call to parse() on the same Case instance should return a
+ * matching String.
+ *
+ * @since 1.11
+ */
+public interface Case {
+
+    /**
+     * Formats a set of tokens into a string. The tokens do not necessarily have to meet the syntax
+     * requirements of the Case. The documentation for each implementation should specify what input
+     * is supported.
+     *
+     * @param tokens string tokens to be formatted by this Case
+     * @return the formatted string
+     */
+    String format(Iterable<String> tokens);
+
+    /**
+     * Parses a string into a series of tokens. The string must abide by certain restrictions,
+     * dependent on each Case implementation.
+     *
+     * @param string The string to be parsed by the Case into a list of tokens
+     * @return The list of parsed tokens
+     */
+    List<String> parse(String string);
+
+}

--- a/src/main/java/org/apache/commons/text/cases/DelimitedCase.java
+++ b/src/main/java/org/apache/commons/text/cases/DelimitedCase.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.CharUtils;
+
+/**
+ * DelimitedCase is a case in which the true alphabetic case of the characters is ignored by default
+ * and tokens themselves are determined by the presence of a delimiter between each token.
+ */
+public class DelimitedCase implements Case {
+
+    /** delimiters to be used when parsing. */
+    private Set<Integer> parseDelimiters;
+
+    /** delimited to be used when formatting. */
+    private String formatDelimiter;
+
+    /**
+     * Constructs a new Delimited Case.
+     * @param delimiter the character to use as both the parse and format delimiter
+     */
+    public DelimitedCase(char delimiter) {
+        this(new char[] { delimiter }, CharUtils.toString(delimiter));
+    }
+
+    /**
+     * Constructs a new delimited case.
+     * @param parseDelimiters The array of delimiters to use when parsing
+     * @param formatDelimiter The delimiter to use when formatting
+     */
+    public DelimitedCase(char[] parseDelimiters, String formatDelimiter) {
+        super();
+        if (parseDelimiters == null || parseDelimiters.length == 0) {
+            throw new IllegalArgumentException("Parse Delimiters cannot be null or empty");
+        }
+        if (formatDelimiter == null || formatDelimiter.length() == 0) {
+            throw new IllegalArgumentException("Format Delimiters cannot be null or empty");
+        }
+        this.parseDelimiters = generateDelimiterSet(parseDelimiters);
+        this.formatDelimiter = formatDelimiter;
+    }
+
+    /**
+     * Formats tokens into Delimited Case.
+     * <p>
+     * Tokens are iterated on and appended to an output stream, with an instance of a
+     * delimiter character between them. This method validates that the delimiter character is not
+     * part of the token. If it is found within the token an exception is thrown.<br>
+     * No other restrictions are placed on the contents of the tokens.
+     * Note: This Case does support empty tokens.<br>
+     * </p>
+     * @param tokens the tokens to be formatted into a delimited string
+     * @return The delimited string
+     */
+    @Override
+    public String format(Iterable<String> tokens) {
+        StringBuilder formattedString = new StringBuilder();
+        int i = 0;
+        for (String token : tokens) {
+            int delimiterFoundIndex = token.indexOf(formatDelimiter);
+            if (delimiterFoundIndex > -1) {
+                throw new IllegalArgumentException("Token " + i + " contains delimiter character '" + formatDelimiter + "' at index " + delimiterFoundIndex);
+            }
+            if (i > 0) {
+                formattedString.append(formatDelimiter);
+            }
+            i++;
+            formattedString.append(token);
+        }
+        return formattedString.toString();
+    }
+
+    /**
+     * Parses delimited string into tokens.
+     * <p>
+     * Input string is parsed one character at a time until a delimiter character is reached.
+     * When a delimiter character is reached a new token begins. The delimiter character is
+     * considered reserved, and is omitted from the returned parsed tokens.<br>
+     * No other restrictions are placed on the contents of the input string. <br>
+     * </p>
+     * @param string The delimited string to be parsed
+     * @return The list of tokens found in the string
+     */
+    @Override
+    public List<String> parse(String string) {
+        List<String> tokens = new LinkedList<>();
+        if (string.length() == 0) {
+            return tokens;
+        }
+        int strLen = string.length();
+        int[] tokenCodePoints = new int[strLen];
+        int tokenCodePointsOffset = 0;
+        for (int i = 0; i < string.length();) {
+            final int codePoint = string.codePointAt(i);
+            if (parseDelimiters.contains(codePoint)) {
+                tokens.add(new String(tokenCodePoints, 0, tokenCodePointsOffset));
+                tokenCodePoints = new int[strLen];
+                tokenCodePointsOffset = 0;
+                i++;
+            } else {
+                tokenCodePoints[tokenCodePointsOffset++] = codePoint;
+                i += Character.charCount(codePoint);
+            }
+        }
+        tokens.add(new String(tokenCodePoints, 0, tokenCodePointsOffset));
+        return tokens;
+    }
+
+    /**
+     * Converts an array of delimiters to a hash set of code points. The generated hash set provides O(1) lookup time.
+     *
+     * @param delimiters set of characters to determine capitalization, null means whitespace
+     * @return Set<Integer>
+     */
+    private static Set<Integer> generateDelimiterSet(final char[] delimiters) {
+        final Set<Integer> delimiterHashSet = new HashSet<>();
+        for (int index = 0; index < delimiters.length; index++) {
+            delimiterHashSet.add(Character.codePointAt(delimiters, index));
+        }
+        return delimiterHashSet;
+    }
+
+}

--- a/src/main/java/org/apache/commons/text/cases/KebabCase.java
+++ b/src/main/java/org/apache/commons/text/cases/KebabCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+/**
+ * Case implementation which parses and formats strings of the form 'my-kebab-string'
+ * <p>
+ * KebabCase is a delimited case where the delimiter is a hyphen character '-'.
+ * </p>
+ */
+public class KebabCase extends DelimitedCase {
+
+    /** constant for delimiter. */
+    public static final char DELIMITER = '-';
+
+    /** constant reuseable instance of this case. */
+    public static final KebabCase INSTANCE = new KebabCase();
+
+    /**
+     * Constructs a new KebabCase instance.
+     */
+    public KebabCase() {
+        super(DELIMITER);
+    }
+
+}

--- a/src/main/java/org/apache/commons/text/cases/PascalCase.java
+++ b/src/main/java/org/apache/commons/text/cases/PascalCase.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.CharUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Case implementation which parses and formats strings of the form 'MyPascalString'
+ * <p>
+ * PascalCase is a case where tokens are delimited by uppercase characters. Each parsed token
+ * <b>must</b> begin with an uppercase character, but the case of the remaining token characters is
+ * ignored and returned as-is.
+ * </p>
+ */
+public class PascalCase implements Case {
+
+    /** constant reuseable instance of this case. */
+    public static final PascalCase INSTANCE = new PascalCase();
+
+    /**
+     * Constructs a new PascalCase instance.
+     */
+    public PascalCase() {
+    }
+
+    /**
+     * Parses a PascalCase string into tokens.
+     * <p>
+     * String characters are iterated over and any time an upper case ascii character is
+     * encountered, that character is considered to be the start of a new token, with the character
+     * itself included in the token. This method should never return empty tokens. The first
+     * character of the string must be an uppercase ascii character. No further restrictions are
+     * placed on string contents.
+     * </p>
+     * @param string The Pascal Cased string to parse
+     * @return the list of tokens found in the string
+     */
+    @Override
+    public List<String> parse(String string) {
+        List<String> tokens = new LinkedList<>();
+        if (string.length() == 0) {
+            return tokens;
+        }
+        if (!CharUtils.isAsciiAlphaUpper(string.charAt(0))) {
+            throw new IllegalArgumentException("Character '" + string.charAt(0) + "' at index 0 must be ascii uppercase");
+        }
+        int strLen = string.length();
+        int[] tokenCodePoints = new int[strLen];
+        int tokenCodePointsOffset = 0;
+        for (int i = 0; i < string.length();) {
+            final int codePoint = string.codePointAt(i);
+            if (CharUtils.isAsciiAlphaUpper((char) codePoint)) {
+                if (tokenCodePointsOffset > 0) {
+                    tokens.add(new String(tokenCodePoints, 0, tokenCodePointsOffset));
+                    tokenCodePoints = new int[strLen];
+                    tokenCodePointsOffset = 0;
+                }
+                tokenCodePoints[tokenCodePointsOffset++] = codePoint;
+                i += Character.charCount(codePoint);
+            } else {
+                tokenCodePoints[tokenCodePointsOffset++] = codePoint;
+                i += Character.charCount(codePoint);
+            }
+        }
+        tokens.add(new String(tokenCodePoints, 0, tokenCodePointsOffset));
+        return tokens;
+    }
+
+    /**
+     * Formats string tokens into a Pascal Case string.
+     * <p>
+     * Iterates the tokens and formates each one into a Pascal Case token. The first character of
+     * the token must be an ascii alpha character. This character is forced upper case in the
+     * output. The remaining alpha characters of the token are forced lowercase. Any other
+     * characters in the token are returned as-is. Empty tokens are not supported.
+     * </p>
+     * @param tokens The string tokens to be formatted into Pascal Case
+     * @return The Pascal Case formatted string
+     */
+    @Override
+    public String format(Iterable<String> tokens) {
+        StringBuilder formattedString = new StringBuilder();
+        int i = 0;
+        for (String token : tokens) {
+            if (token.length() == 0) {
+                throw new IllegalArgumentException("Unsupported empty token at index " + i);
+            }
+            if (!CharUtils.isAsciiAlpha(token.charAt(0))) {
+                throw new IllegalArgumentException("First character '" + token.charAt(0) + "' in token " + i + " must be an ascii letter");
+            }
+            String formattedToken = token.substring(0, 1).toUpperCase() + (token.length() > 1 ? token.substring(1).toLowerCase() : StringUtils.EMPTY);
+            i++;
+            formattedString.append(formattedToken);
+        }
+        return formattedString.toString();
+
+    }
+
+}

--- a/src/main/java/org/apache/commons/text/cases/SnakeCase.java
+++ b/src/main/java/org/apache/commons/text/cases/SnakeCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+/**
+ * Case implementation which parses and formats strings of the form 'my_snake_string'
+ * <p>
+ * SnakeCase is a delimited case where the delimiter is the underscore character '_'.
+ * </p>
+ */
+public class SnakeCase extends DelimitedCase {
+
+    /** constant for delimiter. */
+    public static final char DELIMITER = '_';
+
+    /** constant reuseable instance of this case. */
+    public static final SnakeCase INSTANCE = new SnakeCase();
+
+    /**
+     * Constructs a new SnakeCase instance.
+     */
+    public SnakeCase() {
+        super(DELIMITER);
+    }
+
+}

--- a/src/main/java/org/apache/commons/text/cases/package-info.java
+++ b/src/main/java/org/apache/commons/text/cases/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>Provides algorithms for parsing and formatting various programming "Cases".</p>
+ * <p>The provided implementations are for the four most common cases:<br>
+ * CamelCase - delimited by ascii uppercase alpha characters and always beginning with a lowercase ascii alpha<br>
+ * PascalCase - Similar to CamelCase but always begins with an uppercase ascii alpha<br>
+ * DelimitedCase - delimited by a constant character, which is omitted from parsed tokens<br>
+ * SnakeCase - implementation of DelimitedCase in which the delimiter is an underscore '_'<br>
+ * KebabCase - implementation of DelimitedCase in which the delimiter is a hyphen '-'<br>
+ * </p>
+ *
+ * @since 1.0
+ */
+package org.apache.commons.text.cases;

--- a/src/test/java/org/apache/commons/text/cases/CasesTest.java
+++ b/src/test/java/org/apache/commons/text/cases/CasesTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.cases;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CasesTest {
+
+    @Test
+    public void testDelimiterCharacterException() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> KebabCase.INSTANCE.format(Arrays.asList("a", "-")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> SnakeCase.INSTANCE.format(Arrays.asList("a", "_")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new DelimitedCase(null, ","));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new DelimitedCase(new char[1], null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new DelimitedCase(new char[0], ","));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new DelimitedCase(new char[0], ""));
+    }
+
+    @Test
+    public void testKebabCase() {
+        assertFormatAndParse(KebabCase.INSTANCE, "", Arrays.asList());
+        assertFormatAndParse(KebabCase.INSTANCE, "my-Tokens-123-a1", Arrays.asList("my", "Tokens", "123", "a1"));
+        assertFormatAndParse(KebabCase.INSTANCE, "blank--token", Arrays.asList("blank", "", "token"));
+    }
+
+    @Test
+    public void testUtf32() {
+        assertFormatAndParse(KebabCase.INSTANCE, "\uD800\uDF00-\uD800\uDF01\uD800\uDF14-\uD800\uDF02\uD800\uDF03",
+                Arrays.asList("\uD800\uDF00", "\uD800\uDF01\uD800\uDF14", "\uD800\uDF02\uD800\uDF03"));
+        assertFormatAndParse(SnakeCase.INSTANCE, "\uD800\uDF00_\uD800\uDF01\uD800\uDF14_\uD800\uDF02\uD800\uDF03",
+                Arrays.asList("\uD800\uDF00", "\uD800\uDF01\uD800\uDF14", "\uD800\uDF02\uD800\uDF03"));
+        assertFormatAndParse(PascalCase.INSTANCE, "A\uD800\uDF00B\uD800\uDF01\uD800\uDF14C\uD800\uDF02\uD800\uDF03",
+                Arrays.asList("A\uD800\uDF00", "B\uD800\uDF01\uD800\uDF14", "C\uD800\uDF02\uD800\uDF03"));
+        assertFormatAndParse(CamelCase.INSTANCE, "a\uD800\uDF00B\uD800\uDF01\uD800\uDF14C\uD800\uDF02\uD800\uDF03",
+                Arrays.asList("a\uD800\uDF00", "B\uD800\uDF01\uD800\uDF14", "C\uD800\uDF02\uD800\uDF03"));
+    }
+
+    @Test
+    public void testSnakeCase() {
+        assertFormatAndParse(SnakeCase.INSTANCE, "", Arrays.asList());
+        assertFormatAndParse(SnakeCase.INSTANCE, "my_Tokens_123_a1", Arrays.asList("my", "Tokens", "123", "a1"));
+        assertFormatAndParse(SnakeCase.INSTANCE, "blank__token", Arrays.asList("blank", "", "token"));
+    }
+
+    @Test
+    public void testPascalCase() {
+
+        assertFormatAndParse(PascalCase.INSTANCE, "MyVarName", Arrays.asList("My", "Var", "Name"));
+        assertFormatAndParse(PascalCase.INSTANCE, "MyTokensA1D", Arrays.asList("My", "Tokens", "A1", "D"));
+        assertFormatAndParse(PascalCase.INSTANCE, "", Arrays.asList());
+
+        // first character must be ascii alpha upper
+        Assertions.assertThrows(IllegalArgumentException.class, () -> PascalCase.INSTANCE.parse("lowerFirst"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> PascalCase.INSTANCE.format(Arrays.asList("1")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> PascalCase.INSTANCE.format(Arrays.asList("")));
+    }
+
+    @Test
+    public void testCamelCase() {
+
+        assertFormatAndParse(CamelCase.INSTANCE, "", Arrays.asList());
+        assertFormatAndParse(CamelCase.INSTANCE, "myTokensAbc123", Arrays.asList("my", "Tokens", "Abc123"));
+        assertFormatAndParse(CamelCase.INSTANCE, "specChar-Token+", Arrays.asList("spec", "Char-", "Token+"));
+
+        // empty token not supported
+        Assertions.assertThrows(IllegalArgumentException.class, () -> CamelCase.INSTANCE.format(Arrays.asList("a", "b", "")));
+        // must begin with ascii alpha
+        Assertions.assertThrows(IllegalArgumentException.class, () -> CamelCase.INSTANCE.format(Arrays.asList("a", "1b")));
+        // must begin with ascii alpha lower
+        Assertions.assertThrows(IllegalArgumentException.class, () -> CamelCase.INSTANCE.parse("MyTokens"));
+    }
+
+    @Test
+    public void testConversionsDelimited() {
+
+        List<String> tokens = Arrays.asList("My", "var", "NAME", "mIXED", "a1", "12", "");
+
+        String kebabString = "My-var-NAME-mIXED-a1-12-";
+        assertFormatAndParse(KebabCase.INSTANCE, kebabString, tokens);
+
+        String snakeString = "My_var_NAME_mIXED_a1_12_";
+        assertFormatAndParse(SnakeCase.INSTANCE, snakeString, tokens);
+    }
+
+    @Test
+    public void testConversions() {
+
+        List<String> tokens = Arrays.asList("My", "var", "NAME", "mIXED", "a1", "c|=+");
+
+        String kebabString = "My-var-NAME-mIXED-a1-c|=+";
+        assertFormatAndParse(KebabCase.INSTANCE, kebabString, tokens);
+
+        String snakeString = "My_var_NAME_mIXED_a1_c|=+";
+        assertFormatAndParse(SnakeCase.INSTANCE, snakeString, tokens);
+
+        String camelString = "myVarNameMixedA1C|=+";
+        assertFormatAndParse(CamelCase.INSTANCE, camelString, tokens, true);
+
+        String pascalString = "MyVarNameMixedA1C|=+";
+        assertFormatAndParse(PascalCase.INSTANCE, pascalString, tokens, true);
+
+    }
+
+    @Test
+    public void testEmptyTokens() {
+        List<String> tokens = Arrays.asList("HAS", "", "empty", "Tokens", "");
+
+        String snakeString = "HAS__empty_Tokens_";
+        assertFormatAndParse(SnakeCase.INSTANCE, snakeString, tokens);
+
+        String kebabString = "HAS--empty-Tokens-";
+        assertFormatAndParse(KebabCase.INSTANCE, kebabString, tokens);
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> PascalCase.INSTANCE.format(tokens));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> CamelCase.INSTANCE.format(tokens));
+    }
+
+    public void assertFormatAndParse(Case caseInstance, String string, List<String> tokens) {
+        assertFormatAndParse(caseInstance, string, tokens, false);
+    }
+
+    /**
+     * Test Util method for ensuring that a case instance produces the expecting string and tokens
+     * upon formatting and parsing
+     *
+     * @param case Instance the case instance to use
+     * @param string the expected formatted string
+     * @param tokens the expected tokens
+     * @param caseInsensitive whether to not to validate tokens case insensitively
+     */
+    public void assertFormatAndParse(Case caseInstance, String string, List<String> tokens, Boolean caseInsensitive) {
+        List<String> parsedTokens = caseInstance.parse(string);
+        if (caseInsensitive) {
+            assertEqualsIgnoreCase(tokens, parsedTokens);
+        } else {
+            Assertions.assertEquals(tokens, parsedTokens);
+        }
+        String formatted = caseInstance.format(tokens);
+        Assertions.assertEquals(string, formatted);
+    }
+
+    public void assertEqualsIgnoreCase(List<String> expected, List<String> actual) {
+        Assertions.assertEquals(expected.size(), actual.size());
+        Iterator<String> itEx = expected.iterator();
+        Iterator<String> itAc = actual.iterator();
+        for (; itEx.hasNext();) {
+            Assertions.assertEquals(itEx.next().toLowerCase(), itAc.next().toLowerCase());
+        }
+    }
+
+}
+


### PR DESCRIPTION
This is a more formal API for parsing and formatting strings of various "Cases". 

Similar logic is present in `org.apache.commons.text.CaseUtils` as well as #360 to add two additional case functions, but that code is based around the initial string having delimiters, and cannot translate between cases. This API aims to be slightly more formal, expecting the inputs to the parse method to abide by the syntax of the case. No assumptions (other than the Case syntax) are made about the inputs, and removal of unwanted characters is left to the user. Case classes can be sub classed as necessary to support that.

The Case interface exposes two methods...
```
String format(Iterable<String> tokens)
List<String> parse(String string)
```
with parse() returning a List of String tokens, which can then be passed to another Case instance format() method. Allowing users to change the case of a string e.g. `CamelCase.INSTANCE.format(KebabCase.INSTANCE.parse("my-kebab-string"))`. I followed the pattern of other commons-text classes in using code points rather than primitive chars (I assume to support UTF32).

