### PR TITLE
TEXT-228: Fix TextStringBuilder to over-allocate when ensuring capacity

### DIFF
--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -282,6 +282,18 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     private static final int TRUE_STRING_SIZE = Boolean.TRUE.toString().length();
 
     /**
+     * The maximum size buffer to allocate.
+     *
+     * <p>This is set to the same size used in the JDK {@code java.util.ArrayList}:</p>
+     * <blockquote>
+     * Some VMs reserve some header words in an array.
+     * Attempts to allocate larger arrays may result in
+     * OutOfMemoryError: Requested array size exceeds VM limit.
+     * </blockquote>
+     */
+    private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+
+    /**
      * Constructs an instance from a reference to a character array. Changes to the input chars are reflected in this
      * instance until the internal buffer needs to be reallocated. Using a reference to an array allows the instance to
      * be initialized without copying the input array.
@@ -391,10 +403,10 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     public TextStringBuilder append(final boolean value) {
         if (value) {
-            ensureCapacity(size + TRUE_STRING_SIZE);
+            ensureCapacityInternal(size + TRUE_STRING_SIZE);
             appendTrue(size);
         } else {
-            ensureCapacity(size + FALSE_STRING_SIZE);
+            ensureCapacityInternal(size + FALSE_STRING_SIZE);
             appendFalse(size);
         }
         return this;
@@ -409,7 +421,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     @Override
     public TextStringBuilder append(final char ch) {
         final int len = length();
-        ensureCapacity(len + 1);
+        ensureCapacityInternal(len + 1);
         buffer[size++] = ch;
         return this;
     }
@@ -427,7 +439,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         final int strLen = chars.length;
         if (strLen > 0) {
             final int len = length();
-            ensureCapacity(len + strLen);
+            ensureCapacityInternal(len + strLen);
             System.arraycopy(chars, 0, buffer, len, strLen);
             size += strLen;
         }
@@ -458,7 +470,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         if (length > 0) {
             final int len = length();
-            ensureCapacity(len + length);
+            ensureCapacityInternal(len + length);
             System.arraycopy(chars, startIndex, buffer, len, length);
             size += length;
         }
@@ -496,7 +508,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
                 throw new StringIndexOutOfBoundsException("length must be valid");
             }
             final int len = length();
-            ensureCapacity(len + length);
+            ensureCapacityInternal(len + length);
             System.arraycopy(buf.array(), buf.arrayOffset() + buf.position() + startIndex, buffer, len, length);
             size += length;
         } else {
@@ -643,7 +655,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         if (length > 0) {
             final int len = length();
-            ensureCapacity(len + length);
+            ensureCapacityInternal(len + length);
             str.getChars(startIndex, startIndex + length, buffer, len);
             size += length;
         }
@@ -692,7 +704,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         if (length > 0) {
             final int len = length();
-            ensureCapacity(len + length);
+            ensureCapacityInternal(len + length);
             str.getChars(startIndex, startIndex + length, buffer, len);
             size += length;
         }
@@ -729,7 +741,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         if (length > 0) {
             final int len = length();
-            ensureCapacity(len + length);
+            ensureCapacityInternal(len + length);
             str.getChars(startIndex, startIndex + length, buffer, len);
             size += length;
         }
@@ -766,7 +778,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         if (length > 0) {
             final int len = length();
-            ensureCapacity(len + length);
+            ensureCapacityInternal(len + length);
             str.getChars(startIndex, startIndex + length, buffer, len);
             size += length;
         }
@@ -858,7 +870,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     public TextStringBuilder appendFixedWidthPadLeft(final Object obj, final int width, final char padChar) {
         if (width > 0) {
-            ensureCapacity(size + width);
+            ensureCapacityInternal(size + width);
             String str = obj == null ? getNullText() : obj.toString();
             if (str == null) {
                 str = StringUtils.EMPTY;
@@ -903,7 +915,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     public TextStringBuilder appendFixedWidthPadRight(final Object obj, final int width, final char padChar) {
         if (width > 0) {
-            ensureCapacity(size + width);
+            ensureCapacityInternal(size + width);
             String str = obj == null ? getNullText() : obj.toString();
             if (str == null) {
                 str = StringUtils.EMPTY;
@@ -1162,7 +1174,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     public TextStringBuilder appendPadding(final int length, final char padChar) {
         if (length >= 0) {
-            ensureCapacity(size + length);
+            ensureCapacityInternal(size + length);
             for (int i = 0; i < length; i++) {
                 buffer[size++] = padChar;
             }
@@ -1820,15 +1832,82 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     /**
      * Tests the capacity and ensures that it is at least the size specified.
      *
+     * <p>Note: This method can be used to minimise memory reallocations during
+     * repeated addition of values by pre-allocating the character buffer.
+     * The method ignores a negative {@code capacity} argument.
+     *
      * @param capacity the capacity to ensure
      * @return this, to enable chaining
+     * @throws OutOfMemoryError if the capacity cannot be allocated
      */
     public TextStringBuilder ensureCapacity(final int capacity) {
-        // checks for overflow
-        if (capacity > 0 && capacity - buffer.length > 0) {
-            reallocate(capacity);
+        if (capacity > 0) {
+            ensureCapacityInternal(capacity);
         }
         return this;
+    }
+
+    /**
+     * Ensure that the buffer is at least the size specified. The {@code capacity} argument
+     * is treated as an unsigned integer.
+     *
+     * <p>This method will raise an {@link OutOfMemoryError} if the capacity is too large
+     * for an array, or cannot be allocated.
+     *
+     * @param capacity the capacity to ensure
+     * @throws OutOfMemoryError if the capacity cannot be allocated
+     */
+    private void ensureCapacityInternal(final int capacity) {
+        // Check for overflow of the current buffer.
+        // Assumes capacity is an unsigned integer up to Integer.MAX_VALUE * 2
+        // (the largest possible addition of two maximum length arrays).
+        if (capacity - buffer.length > 0) {
+            resizeBuffer(capacity);
+        }
+    }
+
+    /**
+     * Resizes the buffer to at least the size specified.
+     *
+     * @param minCapacity the minimum required capacity
+     * @throws OutOfMemoryError if the {@code minCapacity} is negative
+     */
+    private void resizeBuffer(final int minCapacity) {
+        // Overflow-conscious code treats the min and new capacity as unsigned.
+        final int oldCapacity = buffer.length;
+        int newCapacity = oldCapacity * 2;
+        if (Integer.compareUnsigned(newCapacity, minCapacity) < 0) {
+            newCapacity = minCapacity;
+        }
+        if (Integer.compareUnsigned(newCapacity, MAX_BUFFER_SIZE) > 0) {
+            newCapacity = createPositiveCapacity(minCapacity);
+        }
+        reallocate(newCapacity);
+    }
+
+    /**
+     * Create a positive capacity at least as large the minimum required capacity.
+     * If the minimum capacity is negative then this throws an OutOfMemoryError as no array
+     * can be allocated.
+     *
+     * @param minCapacity the minimum capacity
+     * @return the capacity
+     * @throws OutOfMemoryError if the {@code minCapacity} is negative
+     */
+    private static int createPositiveCapacity(final int minCapacity) {
+        if (minCapacity < 0) {
+            // overflow
+            throw new OutOfMemoryError("Unable to allocate array size: " + Integer.toUnsignedString(minCapacity));
+        }
+        // This is called when we require buffer expansion to a very big array.
+        // Use the conservative maximum buffer size if possible, otherwise the biggest required.
+        //
+        // Note: In this situation JDK 1.8 java.util.ArrayList returns Integer.MAX_VALUE.
+        // This excludes some VMs that can exceed MAX_BUFFER_SIZE but not allocate a full
+        // Integer.MAX_VALUE length array.
+        // The result is that we may have to allocate an array of this size more than once if
+        // the capacity must be expanded again.
+        return Math.max(minCapacity, MAX_BUFFER_SIZE);
     }
 
     /**
@@ -2107,11 +2186,11 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     public TextStringBuilder insert(final int index, final boolean value) {
         validateIndex(index);
         if (value) {
-            ensureCapacity(size + TRUE_STRING_SIZE);
+            ensureCapacityInternal(size + TRUE_STRING_SIZE);
             System.arraycopy(buffer, index, buffer, index + TRUE_STRING_SIZE, size - index);
             appendTrue(index);
         } else {
-            ensureCapacity(size + FALSE_STRING_SIZE);
+            ensureCapacityInternal(size + FALSE_STRING_SIZE);
             System.arraycopy(buffer, index, buffer, index + FALSE_STRING_SIZE, size - index);
             appendFalse(index);
         }
@@ -2128,7 +2207,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     public TextStringBuilder insert(final int index, final char value) {
         validateIndex(index);
-        ensureCapacity(size + 1);
+        ensureCapacityInternal(size + 1);
         System.arraycopy(buffer, index, buffer, index + 1, size - index);
         buffer[index] = value;
         size++;
@@ -2150,7 +2229,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         final int len = chars.length;
         if (len > 0) {
-            ensureCapacity(size + len);
+            ensureCapacityInternal(size + len);
             System.arraycopy(buffer, index, buffer, index + len, size - index);
             System.arraycopy(chars, 0, buffer, index, len);
             size += len;
@@ -2180,7 +2259,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
             throw new StringIndexOutOfBoundsException("Invalid length: " + length);
         }
         if (length > 0) {
-            ensureCapacity(size + length);
+            ensureCapacityInternal(size + length);
             System.arraycopy(buffer, index, buffer, index + length, size - index);
             System.arraycopy(chars, offset, buffer, index, length);
             size += length;
@@ -2269,7 +2348,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
             final int strLen = str.length();
             if (strLen > 0) {
                 final int newSize = size + strLen;
-                ensureCapacity(newSize);
+                ensureCapacityInternal(newSize);
                 System.arraycopy(buffer, index, buffer, index + strLen, size - index);
                 size = newSize;
                 str.getChars(0, strLen, buffer, index);
@@ -2514,7 +2593,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     public int readFrom(final CharBuffer charBuffer) {
         final int oldSize = size;
         final int remaining = charBuffer.remaining();
-        ensureCapacity(size + remaining);
+        ensureCapacityInternal(size + remaining);
         charBuffer.get(buffer, size, remaining);
         size += remaining;
         return size - oldSize;
@@ -2539,7 +2618,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         final int oldSize = size;
         while (true) {
-            ensureCapacity(size + 1);
+            ensureCapacityInternal(size + 1);
             final CharBuffer buf = CharBuffer.wrap(buffer, size, buffer.length - size);
             final int read = readable.read(buf);
             if (read == EOS) {
@@ -2563,14 +2642,14 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     public int readFrom(final Reader reader) throws IOException {
         final int oldSize = size;
-        ensureCapacity(size + 1);
+        ensureCapacityInternal(size + 1);
         int readCount = reader.read(buffer, size, buffer.length - size);
         if (readCount == EOS) {
             return EOS;
         }
         do {
             size += readCount;
-            ensureCapacity(size + 1);
+            ensureCapacityInternal(size + 1);
             readCount = reader.read(buffer, size, buffer.length - size);
         } while (readCount != EOS);
         return size - oldSize;
@@ -2593,7 +2672,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
             return 0;
         }
         final int oldSize = size;
-        ensureCapacity(size + count);
+        ensureCapacityInternal(size + count);
         int target = count;
         int readCount = reader.read(buffer, size, target);
         if (readCount == EOS) {
@@ -2775,7 +2854,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         final int insertLen) {
         final int newSize = size - removeLen + insertLen;
         if (insertLen != removeLen) {
-            ensureCapacity(newSize);
+            ensureCapacityInternal(newSize);
             System.arraycopy(buffer, endIndex, buffer, startIndex + insertLen, size - endIndex);
             size = newSize;
         }
@@ -2905,7 +2984,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         if (length < size) {
             size = length;
         } else if (length > size) {
-            ensureCapacity(length);
+            ensureCapacityInternal(length);
             final int oldEnd = size;
             size = length;
             Arrays.fill(buffer, oldEnd, length, '\0');

--- a/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.matcher.StringMatcher;
 import org.apache.commons.text.matcher.StringMatcherFactory;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -891,6 +892,112 @@ public class TextStringBuilderTest {
         // sb.ensureCapacity(Integer.MAX_VALUE / 2);
         sb.ensureCapacity(10_000);
         assertThrows(OutOfMemoryError.class, () -> sb.ensureCapacity(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void testOutOfMemoryError() {
+        // This test is memory hungry requiring at least 7GiB of memory.
+        // By default expansion will double the buffer size. If we repeat
+        // add 1GiB of char data then we require at maximum:
+        // 1GiB char[] data
+        // 2GiB char[] buffer
+        // ~4GiB char[] new buffer during reallocation
+
+        // Attempts to guess the amount of free memory available using
+        // java.lang.Runtime and skipping the test often did not work.
+        // The JVM can allocating large arrays using far more memory than
+        // the raw byte size.
+        // So here we just run the test and return a skip result if the
+        // OutOfMemoryError occurs too early.
+
+        final TextStringBuilder sb = new TextStringBuilder();
+        sb.minimizeCapacity();
+        assertEquals(0, sb.capacity());
+
+        // 1GiB char[] buffer: length is roughly 1/4 the maximum array size
+        final char[] chars = new char[1 << 29];
+
+        // With infinite memory it should be possible to add this 3 times.
+        try {
+            for (int i = 0; i < 3; i++) {
+                sb.append(chars);
+            }
+        } catch (OutOfMemoryError ignored) {
+            Assumptions.abort("Not enough memory for the test");
+        }
+
+        // Now at 3/4 of the maximum array length.
+        // Adding is not possible so we expect an OOM error.
+        assertThrows(OutOfMemoryError.class, () -> sb.append(chars));
+    }
+
+    @Test
+    public void testOutOfMemoryError2() {
+        // This test is memory hungry requiring at least 4GiB of memory
+        // in a single allocation. If not possible then skip the test.
+
+        final TextStringBuilder sb = new TextStringBuilder();
+        sb.minimizeCapacity();
+        assertEquals(0, sb.capacity());
+
+        // Allocate a lot
+        final int small = 10;
+        final int big = Integer.MAX_VALUE - small;
+        final char[] extra = new char[small + 1];
+        try {
+            sb.ensureCapacity(big);
+        } catch (OutOfMemoryError ignored) {
+            Assumptions.abort("Not enough memory for the test");
+        }
+
+        fill(sb, big);
+
+        // Adding more than the maximum array size is not possible so we expect an OOM error.
+        assertThrows(OutOfMemoryError.class, () -> sb.append(extra));
+    }
+
+    @Test
+    public void testOutOfMemoryError3() {
+        // This test is memory hungry requiring at least 2GiB of memory
+        // in a single allocation. If not possible then skip the test.
+
+        final TextStringBuilder sb = new TextStringBuilder();
+        sb.minimizeCapacity();
+        assertEquals(0, sb.capacity());
+
+        final int length = 1 << 30;
+        try {
+            sb.ensureCapacity(length);
+        } catch (OutOfMemoryError ignored) {
+            Assumptions.abort("Not enough memory for the test");
+        }
+
+        fill(sb, length);
+
+        // Adding to itself requires a new buffer above the limits of an array
+        assertThrows(OutOfMemoryError.class, () -> sb.append(sb));
+    }
+
+    /**
+     * Clear the string builder and fill up to the specified length.
+     *
+     * @param sb the string builder
+     * @param length the length
+     */
+    private static void fill(TextStringBuilder sb, int length) {
+        sb.clear();
+        // Some initial data.
+        final int limit = Math.min(64, length);
+        for (int i = 0; i < limit; i++) {
+            sb.append(' ');
+        }
+        // Fill by doubling
+        while (sb.length() * 2L <= length) {
+            sb.append(sb);
+        }
+        // Remaining fill
+        sb.append(sb, 0, length - sb.length());
+        assertEquals(length, sb.length(), "Expected the buffer to be full to the given length");
     }
 
     @Test


### PR DESCRIPTION
This fixes a performance regression where allocation was only using the exact size necessary for the additional chars (resulting in buffer reallocation on each append).