### PR TITLE
Clean up, optimize and fix minor bugs in CaseUtils.toCamelCase

### DIFF
--- a/src/main/java/org/apache/commons/text/CaseUtils.java
+++ b/src/main/java/org/apache/commons/text/CaseUtils.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.StringUtils;
  * @since 1.2
  */
 public class CaseUtils {
-    public static final int SPACE_CODEPOINT = 32;
+    private static final int SPACE_CODEPOINT = 32;
     private static final Set<Integer> DEFAULT_DELIMITER_SET = Set.of(SPACE_CODEPOINT);
 
     /**

--- a/src/test/java/org/apache/commons/text/CaseUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/CaseUtilsTest.java
@@ -72,5 +72,29 @@ public class CaseUtilsTest {
         assertThat(CaseUtils.toCamelCase("\uD800\uDF00 \uD800\uDF02", true)).isEqualTo("\uD800\uDF00\uD800\uDF02");
         assertThat(CaseUtils.toCamelCase("\uD800\uDF00\uD800\uDF01\uD800\uDF14\uD800\uDF02\uD800\uDF03", true, '\uD800',
             '\uDF14')).isEqualTo("\uD800\uDF00\uD800\uDF01\uD800\uDF02\uD800\uDF03");
+
+        // Test edge cases in delimiter set generation:
+        assertThat(CaseUtils.toCamelCase("To camel case", false, null)).isEqualTo("toCamelCase");
+        assertThat(CaseUtils.toCamelCase("To camel case", false, '')).isEqualTo("toCamelCase");
+        assertThat(CaseUtils.toCamelCase("To camel case", false, ' ')).isEqualTo("toCamelCase");
+        assertThat(CaseUtils.toCamelCase("To camel case", false, '?')).isEqualTo("toCamelCase");
+
+        // Test basic Unicode handling:
+        assertThat(CaseUtils.toCamelCase("TØ ÇÆМ€£ çÄßΕ", false, null)).isEqualTo("tøÇæм€£Çäßε");
+
+        // Test non-BMP delimiters:
+        assertThat(CaseUtils.toCamelCase("To😃camel☹️case", false, "😃☹️".toCharArray())).isEqualTo("toCamelCase");
+        assertThat(CaseUtils.toCamelCase("To😃camel☹️case", false, "😃".toCharArray())).isEqualTo("toCamel☹️case");
+
+        // Test mispaired surrogates:
+        assertThat(CaseUtils.toCamelCase("To\uD83Dcamel\uDE03case", false, "😃".toCharArray())).isEqualTo("to\uD83Dcamel\uDE03case");
+        assertThat(CaseUtils.toCamelCase("To😃camel☹️case", false, "\uD83D\uDE03".toCharArray())).isEqualTo("toCamel☹️case");
+        assertThat(CaseUtils.toCamelCase("To😃camel☹️case", false, "\uDE03\uD83D".toCharArray())).isEqualTo("to😃camel☹️case");
+
+        // Test letters with special title case forms:
+        assertThat(CaseUtils.toCamelCase("ǄǄ ǅǅ ǆǆ", true)).isEqualTo("ǅǆǅǆǅǆ");
+
+        // Test letters as delimiters:
+        assertThat(CaseUtils.toCamelCase("ToAcameltcase", false, 'A', 't')).isEqualTo("toCamelCase");
     }
 }

--- a/src/test/java/org/apache/commons/text/CaseUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/CaseUtilsTest.java
@@ -75,7 +75,7 @@ public class CaseUtilsTest {
 
         // Test edge cases in delimiter set generation:
         assertThat(CaseUtils.toCamelCase("To camel case", false, null)).isEqualTo("toCamelCase");
-        assertThat(CaseUtils.toCamelCase("To camel case", false, '')).isEqualTo("toCamelCase");
+        assertThat(CaseUtils.toCamelCase("To camel case", false, new char[0])).isEqualTo("toCamelCase");
         assertThat(CaseUtils.toCamelCase("To camel case", false, ' ')).isEqualTo("toCamelCase");
         assertThat(CaseUtils.toCamelCase("To camel case", false, '?')).isEqualTo("toCamelCase");
 


### PR DESCRIPTION
I was looking for an efficient method to convert a string to camel case and came across CaseUtils.toCamelCase. While the method looked pretty close to what I wanted, I noticed that the implementation seemed somewhat ugly and inefficient and appeared to be buggy in some rare edge cases. Here's a patch to clean it up.

This patch fixes two bugs, both of which can only occur in rare edge cases (if at all):

- In one of the branches of the toCamelCase inner loop, Character.charCount was mistakenly called on the title-case version of the character instead of the original, but the result was still used to increment the index to the original input. If the two counts differed (which I doubt is possible in current Unicode, but could _in theory_ happen in some future Unicode revision), this could cause the following character to be skipped and/or an extra unpaired surrogate to be inserted into the output.

- Due to incorrect indexing in the toDelimiterSet helper method, if a non-BMP character was used as a delimiter, the low surrogate half of the character would also be added to the delimiter set. This can only affect the output if the input string contains mispaired surrogates.

The patch also cleans up the code and improves its performance in several ways:

- Duplicate code to increment the input index in the toCamelCase inner loop is moved out of the `if` statement.
- Ugly code to get the Unicode code point of the ASCII space character (32) is replaced with a constant.
- If no custom delimiters are passed to toCamelCase, a constant single-element delimiter set is used to avoid building a new HashSet on each call.
- Also, when only one custom delimiter character is used, the delimiter set is constructed using `Set.of(a, b)`, which is likely more efficient than using a HashSet.
- The input string in toCamelCase is no longer first converted to all lowercase, but is processed as is, saving some time.

The last change also introduces a minor change to (undocumented and untested) behavior:

- Previously, using uppercase letters as custom delimiters would have no effect, while lowercase custom delimiters would match both their upper and lower case variants. Now custom delimiters are always matched case-sensitively.

I would personally consider the new behavior preferable to the old behavior, both since it makes more sense and since it allows a more efficient implementation. Anyway, while it does not seem likely that anyone would actually ever use letters as custom delimiters for toCamelCase in practice, I have nonetheless added a unit test for this edge case (as well as several others). 