### PR TITLE
[TEXT-175] Fix regression for determining whitespace in WordUtils

### DIFF
--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -300,20 +300,14 @@ public class WordUtils {
      */
     private static Predicate<Integer> generateIsDelimiterFunction(final char[] delimiters) {
         final Predicate<Integer> isDelimiter;
-
         if (delimiters == null || delimiters.length == 0) {
-            if (delimiters == null) {
-                isDelimiter = (c) -> Character.isWhitespace(c);
-            } else {
-                isDelimiter = (c) -> false;
-            }
-
+            isDelimiter = delimiters == null ? Character::isWhitespace : c -> false;
         } else {
             Set<Integer> delimiterSet = new HashSet<>();
             for (int index = 0; index < delimiters.length; index++) {
                 delimiterSet.add(Character.codePointAt(delimiters, index));
             }
-            isDelimiter = (c) -> delimiterSet.contains(c);
+            isDelimiter = delimiterSet::contains;
         }
 
         return isDelimiter;

--- a/src/test/java/org/apache/commons/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/WordUtilsTest.java
@@ -109,6 +109,8 @@ public class WordUtilsTest {
         assertThat(WordUtils.capitalizeFully("i am HERE 123")).isEqualTo("I Am Here 123");
         assertThat(WordUtils.capitalizeFully("I AM HERE 123")).isEqualTo("I Am Here 123");
         assertThat(WordUtils.capitalizeFully("alphabet")).isEqualTo("Alphabet"); // single word
+        assertThat(WordUtils.capitalizeFully("a\tb\nc d")).isEqualTo("A\tB\nC D");
+        assertThat(WordUtils.capitalizeFully("and \tbut \ncleat  dome")).isEqualTo("And \tBut \nCleat  Dome");
     }
 
     @Test
@@ -368,6 +370,8 @@ public class WordUtilsTest {
         assertThat(WordUtils.uncapitalize("I Am Here 123")).isEqualTo("i am here 123");
         assertThat(WordUtils.uncapitalize("i am HERE 123")).isEqualTo("i am hERE 123");
         assertThat(WordUtils.uncapitalize("I AM HERE 123")).isEqualTo("i aM hERE 123");
+        assertThat(WordUtils.uncapitalize("A\tB\nC D")).isEqualTo("a\tb\nc d");
+        assertThat(WordUtils.uncapitalize("And \tBut \nCLEAT  Dome")).isEqualTo("and \tbut \ncLEAT  dome");
     }
 
     @Test


### PR DESCRIPTION
Fixes a regression so that the `Character.isWhitespace(char)` is used instead of just the space character for the `capitalize()` and `uncapitalize()` methods in WordUtils.
