### PR TITLE
[TEXT-XXX] Support ECMAScript \x unescaping in StringEscapeUtils

### DIFF
--- a/src/main/java/org/apache/commons/text/StringEscapeUtils.java
+++ b/src/main/java/org/apache/commons/text/StringEscapeUtils.java
@@ -32,6 +32,7 @@ import org.apache.commons.text.translate.LookupTranslator;
 import org.apache.commons.text.translate.NumericEntityEscaper;
 import org.apache.commons.text.translate.NumericEntityUnescaper;
 import org.apache.commons.text.translate.OctalUnescaper;
+import org.apache.commons.text.translate.HexUnescaper;
 import org.apache.commons.text.translate.UnicodeUnescaper;
 import org.apache.commons.text.translate.UnicodeUnpairedSurrogateRemover;
 
@@ -374,14 +375,13 @@ public class StringEscapeUtils {
         );
     }
 
-    /**
-     * Translator object for unescaping escaped Java.
-     *
-     * While {@link #unescapeJava(String)} is the expected method of use, this
-     * object allows the Java unescaping functionality to be used
-     * as the foundation for a custom translator.
-     */
-    public static final CharSequenceTranslator UNESCAPE_JAVA;
+    private static final CharSequenceTranslator OCTAL_JAVA_TRANSLATOR = new OctalUnescaper();
+
+    private static final CharSequenceTranslator UNICODE_JAVA_TRANSLATOR = new UnicodeUnescaper();
+
+    private static final CharSequenceTranslator CTRL_CHARS_JAVA_TRANSLATOR = new LookupTranslator(EntityArrays.JAVA_CTRL_CHARS_UNESCAPE);
+
+    private static final CharSequenceTranslator UNESCAPE_JAVA_TRANSLATOR;
 
     static {
         final Map<CharSequence, CharSequence> unescapeJavaMap = new HashMap<>();
@@ -389,13 +389,22 @@ public class StringEscapeUtils {
         unescapeJavaMap.put("\\\"", "\"");
         unescapeJavaMap.put("\\'", "'");
         unescapeJavaMap.put("\\", StringUtils.EMPTY);
-        UNESCAPE_JAVA = new AggregateTranslator(
-                new OctalUnescaper(),     // .between('\1', '\377'),
-                new UnicodeUnescaper(),
-                new LookupTranslator(EntityArrays.JAVA_CTRL_CHARS_UNESCAPE),
-                new LookupTranslator(Collections.unmodifiableMap(unescapeJavaMap))
-        );
+        UNESCAPE_JAVA_TRANSLATOR = new LookupTranslator(Collections.unmodifiableMap(unescapeJavaMap));
     }
+
+    /**
+     * Translator object for unescaping escaped Java.
+     *
+     * While {@link #unescapeJava(String)} is the expected method of use, this
+     * object allows the Java unescaping functionality to be used
+     * as the foundation for a custom translator.
+     */
+    public static final CharSequenceTranslator UNESCAPE_JAVA = new AggregateTranslator(
+        OCTAL_JAVA_TRANSLATOR,
+        UNICODE_JAVA_TRANSLATOR,
+        CTRL_CHARS_JAVA_TRANSLATOR,
+        UNESCAPE_JAVA_TRANSLATOR
+    );
 
     /**
      * Translator object for unescaping escaped EcmaScript.
@@ -404,7 +413,13 @@ public class StringEscapeUtils {
      * object allows the EcmaScript unescaping functionality to be used
      * as the foundation for a custom translator.
      */
-    public static final CharSequenceTranslator UNESCAPE_ECMASCRIPT = UNESCAPE_JAVA;
+    public static final CharSequenceTranslator UNESCAPE_ECMASCRIPT = new AggregateTranslator(
+        new HexUnescaper(),
+        OCTAL_JAVA_TRANSLATOR,
+        UNICODE_JAVA_TRANSLATOR,
+        CTRL_CHARS_JAVA_TRANSLATOR,
+        UNESCAPE_JAVA_TRANSLATOR
+    );
 
     /**
      * Translator object for unescaping escaped Json.

--- a/src/main/java/org/apache/commons/text/translate/HexUnescaper.java
+++ b/src/main/java/org/apache/commons/text/translate/HexUnescaper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.text.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Translates escaped ASCII values of the form \\x\[0-9A-Fa-f][0-9A-Fa-f] back to ASCII.
+ */
+public class HexUnescaper extends CharSequenceTranslator {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int translate(final CharSequence input, final int index, final Writer writer) throws IOException {
+        if (input.charAt(index) == '\\' && index + 1 < input.length() && input.charAt(index + 1) == 'x') {
+            if (index + 4 <= input.length()) {
+                // Get 2 hex digits
+                final CharSequence hex = input.subSequence(index + 2, index + 4);
+
+                try {
+                    final int value = Integer.parseInt(hex.toString(), 16);
+                    writer.write((char) value);
+                } catch (final NumberFormatException nfe) {
+                    throw new IllegalArgumentException("Unable to parse ASCII value: " + hex, nfe);
+                }
+                return 4;
+            }
+            throw new IllegalArgumentException("Less than 2 hex digits in ASCII value: '"
+                    + input.subSequence(index, input.length())
+                    + "' due to end of CharSequence");
+        }
+        return 0;
+    }
+}

--- a/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/StringEscapeUtilsTest.java
@@ -456,6 +456,7 @@ public class StringEscapeUtilsTest {
         assertEquals("<script src=\"build/main.bundle.js\"></script>", StringEscapeUtils.unescapeEcmaScript("<script src=\"build/main.bundle.js\"></script>"));
         assertEquals("<script src=\"build/main.bundle.js\"></script>>",
                 StringEscapeUtils.unescapeEcmaScript("<script src=\"build/main.bundle.js\"></script>>"));
+        assertEquals("a=b", StringEscapeUtils.unescapeEcmaScript("a\\x3Db"));
     }
 
     @Test


### PR DESCRIPTION
Currently, `StringEscapeUtils` unescapes ECMAScript using the Java strategy.

This mostly works, but ECMAScript additionally supports `\xCC` escapes, where `CC` is a hex code.

This PR adds support for that, as well as an initial test.

I took the liberty of making the child translators of the Java aggregate translator reusable, so I could basically extend the list for the ES version. If we prefer to duplicate that code or to use a varargs list or something, I'm absolutely fine with that as well.

I just subscribed to the dev list and requested access to Jira. I will update the PR title once I've created the corresponding issue.