### PR TITLE
add missingLookupHandler in InterpolatorStringLookup

### DIFF
--- a/src/main/java/org/apache/commons/text/lookup/StringLookupFactory.java
+++ b/src/main/java/org/apache/commons/text/lookup/StringLookupFactory.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -1040,7 +1041,26 @@ public final class StringLookupFactory {
      */
     public StringLookup interpolatorStringLookup(final Map<String, StringLookup> stringLookupMap, final StringLookup defaultStringLookup,
             final boolean addDefaultLookups) {
-        return new InterpolatorStringLookup(stringLookupMap, defaultStringLookup, addDefaultLookups);
+        return new InterpolatorStringLookup(stringLookupMap, defaultStringLookup, null, addDefaultLookups);
+    }
+
+    /**
+     * Returns a new InterpolatorStringLookup. If {@code addDefaultLookups} is {@code true}, the configured {@link #addDefaultStringLookups(Map) default
+     * lookups} are included in addition to the ones provided in {@code stringLookupMap}. (See the class documentation for details on how default lookups are
+     * configured.)
+     *
+     * @param stringLookupMap     the map of string lookups.
+     * @param defaultStringLookup the default string lookup; this lookup is used when a variable cannot be resolved using the lookups in {@code stringLookupMap}
+     *                            or the configured default lookups (if enabled)
+     * @param missingLookupHandler the handler determines whether to use {@code defaultStringLookup} when no corresponding lookup found for a prefix
+     *                             in {@code stringLookupMap}, if it is null or returns {@code true}, the {@code defaultStringLookup} will be used.
+     * @param addDefaultLookups   whether to use default lookups as described above.
+     * @return a new InterpolatorStringLookup.
+     * @since 1.13.2
+     */
+    public StringLookup interpolatorStringLookup(final Map<String, StringLookup> stringLookupMap, final StringLookup defaultStringLookup,
+                                                 BiPredicate<String, String> missingLookupHandler, final boolean addDefaultLookups) {
+        return new InterpolatorStringLookup(stringLookupMap, defaultStringLookup, missingLookupHandler, addDefaultLookups);
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/lookup/InterpolatorStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/InterpolatorStringLookupTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,6 +95,42 @@ public class InterpolatorStringLookupTest {
         assertNull(value);
         value = lookup.lookup("ctx:" + TESTKEY);
         assertEquals(TESTVAL, value);
+    }
+
+    @Test
+    public void testLookupMissingReturnTrue() {
+        final Map<String, String> map = new HashMap<>();
+        map.put(TESTKEY, TESTVAL);
+        final StringLookup lookup = new InterpolatorStringLookup(Collections.emptyMap(), StringLookupFactory.INSTANCE.mapStringLookup(map),
+                (prefix, key) -> true, true);
+        String value = lookup.lookup(TESTKEY);
+        assertEquals(TESTVAL, value);
+        value = lookup.lookup("ctx:" + TESTKEY);
+        assertEquals(TESTVAL, value);
+        value = lookup.lookup("sys:" + TESTKEY);
+        assertEquals(TESTVAL, value);
+        value = lookup.lookup("BadKey");
+        assertNull(value);
+        value = lookup.lookup("ctx:" + TESTKEY);
+        assertEquals(TESTVAL, value);
+    }
+
+    @Test
+    public void testLookupMissingReturnFalse() {
+        final Map<String, String> map = new HashMap<>();
+        map.put(TESTKEY, TESTVAL);
+        final StringLookup lookup = new InterpolatorStringLookup(Collections.emptyMap(), StringLookupFactory.INSTANCE.mapStringLookup(map),
+                (prefix, key) -> false, true);
+        String value = lookup.lookup(TESTKEY);
+        assertEquals(TESTVAL, value);
+        value = lookup.lookup("ctx:" + TESTKEY);
+        assertNull(value);
+        value = lookup.lookup("sys:" + TESTKEY);
+        assertEquals(TESTVAL, value);
+        value = lookup.lookup("BadKey");
+        assertNull(value);
+        value = lookup.lookup("ctx:" + TESTKEY);
+        assertNull(value);
     }
 
     @Test


### PR DESCRIPTION
Add a missingLookupHandler in `InterpolatorStringLookup`.  
When resolving a variable with prefix，the `InterpolatorStringLookup` finds corresponding lookup by prefix in `stringLookupMap`，when there is no corresponding lookup for the prefix, the `missingLookupHandler ` is used to determine whether to use default lookup.  If the `missingLookupHandler ` is null or returns `true`, the default lookup will be used to resolve the variable. 

This allows user to control the behavior in such case.  For example user can chose using default lookup as before, return null, or throw an exception.
