### PR TITLE
fix: Ensure unique serial number for VEX file

### DIFF
--- a/src/conf/security/VEX.cyclonedx.xml
+++ b/src/conf/security/VEX.cyclonedx.xml
@@ -23,11 +23,11 @@
 <bom xmlns="http://cyclonedx.org/schema/bom/1.6"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd"
-     serialNumber="urn:uuid:f70dec29-fc7d-41f2-8c60-97e9075e0e73"
-     version="1">
+     serialNumber="urn:uuid:9d64577b-0376-4ee7-b154-5ec26a1803f4"
+     version="2">
 
   <metadata>
-    <timestamp>2025-07-29T12:26:42Z</timestamp>
+    <timestamp>2025-08-04T11:45:36Z</timestamp>
     <component type="library" bom-ref="main_component">
       <group>org.apache.commons</group>
       <name>commons-text</name>


### PR DESCRIPTION
This update corrects the serial number in the VEX file, which was mistakenly copied from apache/commons-bcel#446. With this fix, all published VEX files will now have unique serial numbers, preventing potential conflicts or duplication.
