### PR TITLE
[TEXT-236] Fix: TextStringBuilder::insert at the end

### DIFF
--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -3208,10 +3208,10 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     }
 
     /**
-     * Validates that an index is in the range {@code 0 <= index <= size}.
+     * Validates that an index is in the range {@code 0 <= index < size}.
      *
      * @param index the index to test.
-     * @throws IndexOutOfBoundsException Thrown when the index is not the range {@code 0 <= index <= size}.
+     * @throws IndexOutOfBoundsException Thrown when the index is not the range {@code 0 <= index < size}.
      */
     protected void validateIndex(final int index) {
         if (index < 0 || index >= size) {

--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -2190,7 +2190,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, final boolean value) {
-        validateIndex(index, true);
+        validateIndexEndInclusive(index);
         if (value) {
             ensureCapacityInternal(size + TRUE_STRING_SIZE);
             System.arraycopy(buffer, index, buffer, index + TRUE_STRING_SIZE, size - index);
@@ -2212,7 +2212,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, final char value) {
-        validateIndex(index, true);
+        validateIndexEndInclusive(index);
         ensureCapacityInternal(size + 1);
         System.arraycopy(buffer, index, buffer, index + 1, size - index);
         buffer[index] = value;
@@ -2229,7 +2229,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, final char[] chars) {
-        validateIndex(index, true);
+        validateIndexEndInclusive(index);
         if (chars == null) {
             return insert(index, nullText);
         }
@@ -2254,7 +2254,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if any index is invalid
      */
     public TextStringBuilder insert(final int index, final char[] chars, final int offset, final int length) {
-        validateIndex(index, true);
+        validateIndexEndInclusive(index);
         if (chars == null) {
             return insert(index, nullText);
         }
@@ -2346,7 +2346,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, String str) {
-        validateIndex(index, true);
+        validateIndexEndInclusive(index);
         if (str == null) {
             str = nullText;
         }
@@ -3220,13 +3220,12 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
     }
 
     /**
-     * Validates that an index is in the range {@code 0 <= index <= size} or {@code 0 <= index < size}.
+     * Validates that an index is in the range {@code 0 <= index <= size}.
      * @param index the index to test.
-     * @param includeEndInValidRange whether to include the end in the valid range.
      * @throws IndexOutOfBoundsException Thrown when index is not in the chosen range.
      */
-    protected void validateIndex(final int index, final boolean includeEndInValidRange) {
-        if (index < 0 || (includeEndInValidRange ? (index > size) : (index >= size))) {
+    protected void validateIndexEndInclusive(final int index) {
+        if (index < 0 || index > size) {
             throw new StringIndexOutOfBoundsException(index);
         }
     }

--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -2190,7 +2190,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, final boolean value) {
-        validateIndex(index);
+        validateIndex(index, true);
         if (value) {
             ensureCapacityInternal(size + TRUE_STRING_SIZE);
             System.arraycopy(buffer, index, buffer, index + TRUE_STRING_SIZE, size - index);
@@ -2212,7 +2212,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, final char value) {
-        validateIndex(index);
+        validateIndex(index, true);
         ensureCapacityInternal(size + 1);
         System.arraycopy(buffer, index, buffer, index + 1, size - index);
         buffer[index] = value;
@@ -2229,7 +2229,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, final char[] chars) {
-        validateIndex(index);
+        validateIndex(index, true);
         if (chars == null) {
             return insert(index, nullText);
         }
@@ -2254,7 +2254,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if any index is invalid
      */
     public TextStringBuilder insert(final int index, final char[] chars, final int offset, final int length) {
-        validateIndex(index);
+        validateIndex(index, true);
         if (chars == null) {
             return insert(index, nullText);
         }
@@ -2346,7 +2346,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @throws IndexOutOfBoundsException if the index is invalid
      */
     public TextStringBuilder insert(final int index, String str) {
-        validateIndex(index);
+        validateIndex(index, true);
         if (str == null) {
             str = nullText;
         }
@@ -3215,6 +3215,18 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      */
     protected void validateIndex(final int index) {
         if (index < 0 || index >= size) {
+            throw new StringIndexOutOfBoundsException(index);
+        }
+    }
+
+    /**
+     * Validates that an index is in the range {@code 0 <= index <= size} or {@code 0 <= index < size}.
+     * @param index the index to test.
+     * @param includeEndInValidRange whether to include the end in the valid range.
+     * @throws IndexOutOfBoundsException Thrown when index is not in the chosen range.
+     */
+    protected void validateIndex(final int index, final boolean includeEndInValidRange) {
+        if (index < 0 || (includeEndInValidRange ? (index > size) : (index >= size))) {
             throw new StringIndexOutOfBoundsException(index);
         }
     }

--- a/src/test/java/org/apache/commons/text/TextStringBuilderAppendInsertTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderAppendInsertTest.java
@@ -1134,6 +1134,72 @@ class TextStringBuilderAppendInsertTest {
     }
 
     @Test
+    void testInsertAtEnd() {
+        final TextStringBuilder sb = new TextStringBuilder();
+        assertEquals("", sb.toString());
+
+        sb.insert(0, "Hello");
+        assertEquals("Hello", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-1, "World"));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(6, "World"));
+
+        sb.insert(5, true);
+        assertEquals("Hellotrue", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(10, false));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-20, false));
+
+        sb.insert(9, 'A');
+        assertEquals("HellotrueA", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(11, 'B'));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-2, 'B'));
+
+        sb.insert(10, new char[] { 'B' , 'C' });
+        assertEquals("HellotrueABC", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(13, new char[] { 'D', 'E' }));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-1, new char[] { 'D', 'E' }));
+
+        sb.insert(12, new char[] { 'D', 'E', 'F' }, 1, 1);
+        assertEquals("HellotrueABCE", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(14, new char[] { 'G', 'H', 'I' }, 1, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-1, new char[] { 'G', 'H', 'I' }, 1, 1));
+
+        sb.insert(13, 1.2d);
+        assertEquals("HellotrueABCE1.2", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(17, 1.3d));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-1, 1.3d));
+
+        sb.insert(16, 1f);
+        assertEquals("HellotrueABCE1.21.0", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(20, 1.3f));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-3,  1.3f));
+
+        sb.insert(19, 23);
+        assertEquals("HellotrueABCE1.21.023", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(22, 20));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-5, -5));
+
+        sb.insert(21, 99L);
+        assertEquals("HellotrueABCE1.21.02399", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(24, 22L));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-1, -1L));
+
+        sb.insert(23, FOO);
+        assertEquals("HellotrueABCE1.21.02399foo", sb.toString());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(27, FOO));
+        assertThrows(IndexOutOfBoundsException.class, () -> sb.insert(-3, FOO));
+    }
+
+    @Test
     void testInsertWithNullText() {
         final TextStringBuilder sb = new TextStringBuilder();
         sb.setNullText("null");


### PR DESCRIPTION
- Fixed the javadoc for existing `validateIndex` function.
- Added a new `validateIndexEndInclusive` funtion.
- For all validateIndex (older) calls in insert function; replaced with new function.
- Added unit test for insert at end.