### PR TITLE
[TEXT-238]: Add overload CaseUtils.toCamelCase(String, char...) defaulting to lowercase first letter

### DIFF
--- a/src/main/java/org/apache/commons/text/CaseUtils.java
+++ b/src/main/java/org/apache/commons/text/CaseUtils.java
@@ -40,6 +40,39 @@ public class CaseUtils {
      *
      * <p>The delimiters represent a set of characters understood to separate words.
      * The first non-delimiter character after a delimiter will be capitalized. The first String
+     * character will be capitalized.</p>
+     *
+     * <p>A {@code null} input String returns {@code null}.</p>
+     *
+     * <p>A input string with only delimiter characters returns {@code ""}.</p>
+     *
+     * Capitalization uses the Unicode title case, normally equivalent to
+     * upper case and cannot perform locale-sensitive mappings.
+     *
+     * <pre>
+     * CaseUtils.toCamelCase(null)                                   = null
+     * CaseUtils.toCamelCase("", '*')                                = ""
+     * CaseUtils.toCamelCase("*", null)                              = *
+     * CaseUtils.toCamelCase("To.Camel.Case", new char[]{'.'})       = "toCamelCase"
+     * CaseUtils.toCamelCase(" @to @ Camel case", new char[]{'@'})   = "toCamelCase"
+     * CaseUtils.toCamelCase(" @", new char[]{'@'})                  = ""
+     * </pre>
+     *
+     * @param str        the String to be converted to camelCase, may be null
+     * @param delimiters set of characters to determine capitalization, null and/or empty array means whitespace
+     * @return camelCase of String, {@code null} if null String input
+     */
+    public static String toCamelCase(String str, final char... delimiters) {
+        return toCamelCase(str, false, delimiters);
+    }
+
+    /**
+     * Converts all the delimiter separated words in a String into camelCase,
+     * that is each word is made up of a title case character and then a series of
+     * lowercase characters.
+     *
+     * <p>The delimiters represent a set of characters understood to separate words.
+     * The first non-delimiter character after a delimiter will be capitalized. The first String
      * character may or may not be capitalized and it's determined by the user input for capitalizeFirstLetter
      * variable.</p>
      *

--- a/src/test/java/org/apache/commons/text/CaseUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/CaseUtilsTest.java
@@ -43,6 +43,33 @@ class CaseUtilsTest {
     }
 
     @Test
+    void testDefaultToCamelCase() {
+        assertNull(CaseUtils.toCamelCase(null));
+        assertNull(CaseUtils.toCamelCase(null, null));
+        assertEquals("", CaseUtils.toCamelCase("  ", null));
+        assertEquals("aBC@def", CaseUtils.toCamelCase("a  b  c  @def", null));
+
+        final char[] chars = { '-', '+', ' ', '@' };
+        assertEquals("toCamelCase", CaseUtils.toCamelCase("   to-CAMEL-cASE", chars));
+
+        assertEquals("toCamelCase", CaseUtils.toCamelCase("To.Camel.Case", '.'));
+        assertEquals("toCamelCase", CaseUtils.toCamelCase("To.Camel-Case", '-', '.'));
+        assertEquals("toCamelCase", CaseUtils.toCamelCase(" to @ Camel case", '-', '@'));
+
+        assertEquals("toCamelCase", CaseUtils.toCamelCase("TO CAMEL CASE", null));
+        assertEquals("toCamelCase", CaseUtils.toCamelCase("TO CAMEL CASE", null));
+        assertEquals("tocamelcase", CaseUtils.toCamelCase("tocamelcase", null));
+        assertEquals("tocamelcase", CaseUtils.toCamelCase("Tocamelcase", null));
+
+        assertEquals("tocamelcase", CaseUtils.toCamelCase("tocamelcase", false));
+
+        assertEquals("helloWorld", CaseUtils.toCamelCase("hello world"));
+        assertEquals("javaUtils", CaseUtils.toCamelCase("java-utils", '-'));
+        assertEquals("convertThisString", CaseUtils.toCamelCase("convert this string"));
+        assertEquals("helloWorld", CaseUtils.toCamelCase("hello_world", '_'));
+    }
+
+    @Test
     void testToCamelCase() {
         assertNull(CaseUtils.toCamelCase(null, false, null));
         assertEquals("", CaseUtils.toCamelCase("", true, null));


### PR DESCRIPTION
### What this PR does
Implements **[TEXT-238]**: Add a convenience overload to `CaseUtils.toCamelCase`.

Currently, `CaseUtils.toCamelCase(String, boolean, char...)` always requires specifying the `capitalizeFirstLetter` flag.  
In most real-world cases, callers just want camelCase with the first letter lowercased, which is the canonical meaning of camelCase.

This PR adds a new overload:
```java
public static String toCamelCase(String str, char... delimiters) { ... }
```
By default, the first letter is lowercased (capitalizeFirstLetter = false).

Since delimiters is already a varargs parameter, no further overload is needed (e.g., toCamelCase(String) is already supported by omitting delimiters).

This also improves usability in JDK 8+ when using method references, e.g.:
```java
list.stream().map(CaseUtils::toCamelCase)
```

Check List:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
