### PR TITLE
StrBuilder.replaceImpl() and setLength() shrink-branch leaves residual chars in buffer tail

### DIFF
--- a/src/main/java/org/apache/commons/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/text/StrBuilder.java
@@ -1820,6 +1820,15 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
     }
 
     /**
+     * Gets the internal buffer for testing.
+     *
+     * @return the internal buffer.
+     */
+    char[] getBuffer() {
+        return buffer;
+    }
+
+    /**
      * Copies the character array into the specified array.
      *
      * @param destination the destination array, null will cause an array to be created.
@@ -2608,6 +2617,9 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
         if (insertLen != removeLen) {
             ensureCapacity(newSize);
             System.arraycopy(buffer, endIndex, buffer, startIndex + insertLen, size - endIndex);
+            if (size > newSize) {
+                Arrays.fill(buffer, newSize, size, CharUtils.NUL);
+            }
             size = newSize;
         }
         if (insertLen > 0) {
@@ -2720,12 +2732,12 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
             throw new StringIndexOutOfBoundsException(length);
         }
         if (length < size) {
-            size = length;
+            Arrays.fill(buffer, length, size, CharUtils.NUL);
         } else if (length > size) {
             ensureCapacity(length);
             Arrays.fill(buffer, size, length, CharUtils.NUL);
-            size = length;
         }
+        size = length;
         return this;
     }
 

--- a/src/test/java/org/apache/commons/text/StrBuilderClearTest.java
+++ b/src/test/java/org/apache/commons/text/StrBuilderClearTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.commons.text;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,6 +27,7 @@ import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.Test;
 
@@ -135,6 +138,48 @@ public class StrBuilderClearTest {
             sb.readFrom(spy);
             // Post-patch: stale chars must NOT be visible to the Reader
             assertFalse(spy.observedStaleChars("_DATA_SHOULD_NOT_LEAK"));
+        }
+    }
+
+    @Test
+    void testReplaceImplLeavesResidue() throws Exception {
+        final String string = "SECRET_PASSWORD_DATA";
+        final StrBuilder sb = new StrBuilder(string);
+        assertEquals(20, sb.length());
+        // Shrink: replace [0,20) with "X" => removeLen=20, insertLen=1, newSize=1.
+        sb.replace(0, 20, "X");
+        assertEquals(1, sb.length());
+        assertEquals("X", sb.toString());
+        final char[] buf = sb.getBuffer();
+        assertTrue(buf.length >= 20);
+        // Tail [1..20) should be cleared but isn't on baseline => residue persists.
+        // Probe offset 5: original was '_' (underscore from "SECRET_..."). After
+        // arraycopy(buf, endIndex=20, buf, startIndex+insertLen=1, size-endIndex=0)
+        // the shift is a no-op, so buf[5] retains the original 'T' from "SECRET_".
+        // Either way it is non-NUL.
+        assertEquals(CharUtils.NUL, buf[5]);
+        // Dump the visible residue at the logical-unused tail.
+        for (int i = 1; i < 20; i++) {
+            assertEquals(CharUtils.NUL, buf[i]);
+        }
+    }
+
+    @Test
+    void testSetLengthShrinkLeavesResidue() throws Exception {
+        final String string = "CONFIDENTIAL_TOKEN_VALUE";
+        final int len = string.length();
+        final StrBuilder sb = new StrBuilder(string);
+        assertEquals(len, sb.length());
+        // setLength(5) shrinks: size = 5, but [5..24) is NOT cleared.
+        sb.setLength(5);
+        assertEquals(5, sb.length());
+        assertEquals("CONFI", sb.toString());
+        final char[] buf = sb.getBuffer();
+        assertTrue(buf.length >= len);
+        // Probe offset 10: original was 'L' (CONFIDENTIA*L*_TOKEN_VALUE).
+        assertEquals(CharUtils.NUL, buf[10]);
+        for (int i = 5; i < len; i++) {
+            assertEquals(CharUtils.NUL, buf[i]);
         }
     }
 


### PR DESCRIPTION
`StrBuilder.replaceImpl()` shrink-branch leaves residual chars in buffer tail.

`StrBuilder.setLength(int)` shrink-branch leaves residual chars in buffer tail.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] OP used AI to create initial report in Commons Lang.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
