### PR TITLE
Fix path fence bypass for relative paths with leading ".."

### DIFF
--- a/src/main/java/org/apache/commons/text/lookup/PathFence.java
+++ b/src/main/java/org/apache/commons/text/lookup/PathFence.java
@@ -82,7 +82,7 @@ final class PathFence {
      * @param builder A builder.
      */
     private PathFence(final Builder builder) {
-        this.roots = Arrays.stream(builder.roots).map(Path::toAbsolutePath).collect(Collectors.toList());
+        this.roots = Arrays.stream(builder.roots).map(p -> p.toAbsolutePath().normalize()).collect(Collectors.toList());
     }
 
     /**
@@ -97,7 +97,7 @@ final class PathFence {
         if (roots.isEmpty()) {
             return path;
         }
-        final Path pathAbs = path.normalize().toAbsolutePath();
+        final Path pathAbs = path.toAbsolutePath().normalize();
         final Optional<Path> first = roots.stream().filter(pathAbs::startsWith).findFirst();
         if (first.isPresent()) {
             return path;

--- a/src/test/java/org/apache/commons/text/lookup/FileStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/FileStringLookupTest.java
@@ -131,6 +131,17 @@ public class FileStringLookupTest {
     }
 
     @Test
+    void testFenceRootWithParentSegment() throws Exception {
+        // A fence root that itself carries an unresolved ".." segment must be normalized when the
+        // fence is built. Otherwise the component-wise prefix check never matches and a file that
+        // really is inside the fence is wrongly rejected. Here "target/.." resolves to the working
+        // directory, so the in-fence document must still be readable.
+        final String expectedString = readDocumentFixtureString();
+        final FileStringLookup fileStringLookup = new FileStringLookup(Paths.get("target/.."));
+        assertEquals(expectedString, fileStringLookup.apply("UTF-8:src/test/resources/org/apache/commons/text/document.properties"));
+    }
+
+    @Test
     void testFenceEmptyOne() throws Exception {
         final String expectedString = readDocumentFixtureString();
         assertEquals(expectedString, new FileStringLookup().apply("UTF-8:src/test/resources/org/apache/commons/text/document.properties"));

--- a/src/test/java/org/apache/commons/text/lookup/FileStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/FileStringLookupTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests {@link FileStringLookup}.
@@ -116,6 +117,17 @@ public class FileStringLookupTest {
         final String expectedString = readDocumentFixtureString();
         final FileStringLookup fileStringLookup = new FileStringLookup(Paths.get("target"), CURRENT_PATH);
         testFence(expectedString, fileStringLookup);
+    }
+
+    @Test
+    void testFenceRelativeParentTraversal(@TempDir final Path tempDir) throws Exception {
+        // A real, readable file that lives outside the fence but is reachable from the working
+        // directory through leading ".." segments. The fence must reject it; if the leading ".."
+        // survives unresolved, the prefix check passes and the file is read, escaping the fence.
+        final Path secret = Files.write(tempDir.resolve("secret.txt"), "secret".getBytes(StandardCharsets.UTF_8));
+        final Path relativeEscape = CURRENT_PATH.toAbsolutePath().relativize(secret);
+        final FileStringLookup fileStringLookup = new FileStringLookup(CURRENT_PATH);
+        assertThrows(IllegalArgumentException.class, () -> fileStringLookup.apply("UTF-8:" + relativeEscape));
     }
 
     @Test


### PR DESCRIPTION
PathFence.apply() calls path.normalize().toAbsolutePath(), so leading .. segments survive normalize() and toAbsolutePath() then prepends the working directory. The component-wise startsWith(root) check matches the prefix even though the real path escapes the fence, e.g. ${file:UTF-8:../secret} reads outside a fence rooted at the working directory. Resolve to absolute first, then normalize, for both the roots and the candidate path.