### PR TITLE
Validate code point range in NumericEntityUnescaper.translate()

### DIFF
--- a/src/main/java/org/apache/commons/text/translate/NumericEntityUnescaper.java
+++ b/src/main/java/org/apache/commons/text/translate/NumericEntityUnescaper.java
@@ -151,6 +151,9 @@ public class NumericEntityUnescaper extends CharSequenceTranslator {
                 return 0;
             }
 
+            if (!Character.isValidCodePoint(entityValue)) {
+                return 0;
+            }
             if (entityValue > 0xFFFF) {
                 final char[] chrs = Character.toChars(entityValue);
                 writer.write(chrs[0]);

--- a/src/test/java/org/apache/commons/text/translate/NumericEntityUnescaperTest.java
+++ b/src/test/java/org/apache/commons/text/translate/NumericEntityUnescaperTest.java
@@ -54,6 +54,15 @@ class NumericEntityUnescaperTest  {
     }
 
     @Test
+    void testOutOfRangeCodePoint() {
+        final NumericEntityUnescaper neu = new NumericEntityUnescaper();
+
+        assertEquals("&#x110000;", neu.translate("&#x110000;"), "Failed to ignore code point above 0x10FFFF");
+        assertEquals("&#1114112;", neu.translate("&#1114112;"), "Failed to ignore code point above 0x10FFFF");
+        assertEquals("&#x7FFFFFFF;", neu.translate("&#x7FFFFFFF;"), "Failed to ignore code point above 0x10FFFF");
+    }
+
+    @Test
     void testSupplementaryUnescaping() {
         final NumericEntityUnescaper neu = new NumericEntityUnescaper();
         final String input = "&#68642;";


### PR DESCRIPTION
Noticed translate calls Character.toChars(entityValue) for values above 0xFFFF without checking the upper code point bound, so a numeric reference like `&#x110000;` (or `&#1114112;`) throws IllegalArgumentException instead of being left alone. unescapeHtml4 and unescapeXml run this over untrusted markup, where every other malformed entity is silently ignored. Reject out-of-range code points the same way, by returning 0.