### PR TITLE
Fix StringIndexOutOfBoundsException in CsvUnescaper on lone quote

### DIFF
--- a/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
+++ b/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
@@ -74,8 +74,8 @@ public final class CsvTranslators {
 
         @Override
         void translateWhole(final CharSequence input, final Writer writer) throws IOException {
-            // is input not quoted?
-            if (input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE) {
+            // is input not quoted? a single character cannot be wrapped in a leading and trailing quote
+            if (input.length() < 2 || input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE) {
                 writer.write(input.toString());
                 return;
             }

--- a/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
+++ b/src/main/java/org/apache/commons/text/translate/CsvTranslators.java
@@ -74,7 +74,7 @@ public final class CsvTranslators {
 
         @Override
         void translateWhole(final CharSequence input, final Writer writer) throws IOException {
-            // is input not quoted? a single character cannot be wrapped in a leading and trailing quote
+            // Is input not quoted? A single character cannot be wrapped in a leading and trailing quote.
             if (input.length() < 2 || input.charAt(0) != CSV_QUOTE || input.charAt(input.length() - 1) != CSV_QUOTE) {
                 writer.write(input.toString());
                 return;

--- a/src/test/java/org/apache/commons/text/translate/CsvTranslatorsTest.java
+++ b/src/test/java/org/apache/commons/text/translate/CsvTranslatorsTest.java
@@ -78,6 +78,16 @@ class CsvTranslatorsTest {
     }
 
     @Test
+    void testCsvUnEscaperSingleQuoteTest() throws IOException {
+        final CsvTranslators.CsvUnescaper escaper = new CsvTranslators.CsvUnescaper();
+        final Writer writer = new StringWriter();
+        final String input = "\"";
+        escaper.translateWhole(input, writer);
+        final String data = writer.toString();
+        assertEquals(input, data);
+    }
+
+    @Test
     void testCsvUnEscaperPlaneTextTest() throws IOException {
         final CsvTranslators.CsvUnescaper escaper = new CsvTranslators.CsvUnescaper();
         final Writer writer = new StringWriter();


### PR DESCRIPTION
`StringEscapeUtils.unescapeCsv("\"")` throws `StringIndexOutOfBoundsException: String index out of range: -1`.

A single `"` passes the "is this a quoted value" check because `charAt(0)` and `charAt(length - 1)` read the same character, so `CsvUnescaper.translateWhole` strips quotes with `subSequence(1, length - 1)` = `subSequence(1, 0)`. Require length >= 2 so a lone quote falls through unchanged like other unquoted input.