### PR TITLE
Return null for malformed input in UrlDecoderStringLookup

### DIFF
--- a/src/main/java/org/apache/commons/text/lookup/UrlDecoderStringLookup.java
+++ b/src/main/java/org/apache/commons/text/lookup/UrlDecoderStringLookup.java
@@ -58,6 +58,9 @@ final class UrlDecoderStringLookup extends AbstractStringLookup {
         final String enc = StandardCharsets.UTF_8.name();
         try {
             return decode(key, enc);
+        } catch (final IllegalArgumentException e) {
+            // Malformed input such as an incomplete "%" escape; squelch and return null like the other lookups.
+            return null;
         } catch (final UnsupportedEncodingException e) {
             // Can't happen since UTF-8 is required by the Java specification.
             throw IllegalArgumentExceptions.format(e, "%s: source=%s, encoding=%s", e, key, enc);

--- a/src/test/java/org/apache/commons/text/lookup/UrlDecoderStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/UrlDecoderStringLookupTest.java
@@ -55,6 +55,12 @@ class UrlDecoderStringLookupTest {
     }
 
     @Test
+    void testMalformedEscapeReturnsNull() {
+        assertNull(UrlDecoderStringLookup.INSTANCE.apply("%"));
+        assertNull(UrlDecoderStringLookup.INSTANCE.apply("%E0%"));
+    }
+
+    @Test
     void testNull() {
         assertNull(UrlDecoderStringLookup.INSTANCE.apply(null));
     }


### PR DESCRIPTION
UrlDecoderStringLookup.lookup only catches UnsupportedEncodingException, so a malformed percent-escape like ${urlDecoder:%} lets URLDecoder.decode throw IllegalArgumentException straight out of StringSubstitutor.replace on the default interpolator. The sibling decoder lookups already swallow that: FunctionStringLookup catches IllegalArgumentException and returns null, so ${base64Decoder:!} just resolves to nothing. Catch it here too and return null so malformed untrusted input decodes consistently.