### PR TITLE
Throw IllegalArgumentException for trailing whitespace in ExtendedMessageFormat argument index

### DIFF
--- a/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
@@ -442,6 +442,9 @@ public class ExtendedMessageFormat extends MessageFormat {
             char c = pattern.charAt(pos.getIndex());
             if (Character.isWhitespace(c)) {
                 seekNonWs(pattern, pos);
+                if (pos.getIndex() >= pattern.length()) {
+                    break;
+                }
                 c = pattern.charAt(pos.getIndex());
                 if (c != START_FMT && c != END_FE) {
                     error = true;

--- a/src/test/java/org/apache/commons/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/text/ExtendedMessageFormatTest.java
@@ -475,6 +475,11 @@ class ExtendedMessageFormatTest {
     }
 
     @Test
+    void testArgumentIndexTrailingWhitespaceAtEnd() {
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0 ", new HashMap<>()));
+    }
+
+    @Test
     void testOverriddenBuiltinFormat() {
         final Calendar cal = Calendar.getInstance();
         cal.set(2007, Calendar.JANUARY, 23);


### PR DESCRIPTION
**Unhandled StringIndexOutOfBoundsException on a trailing-whitespace argument index**

Reading through readArgumentIndex I noticed that once it has accumulated a digit and then meets whitespace, it calls seekNonWs and immediately does pattern.charAt(pos.getIndex()) again. If that whitespace runs to the end of the pattern the index now equals the length, so a pattern like "{0 " throws StringIndexOutOfBoundsException straight out of the constructor, whereas every other unterminated element ("{0", "{0,number ") reports the documented IllegalArgumentException. I broke out of the loop when the skip reaches the end so it falls through to the existing unterminated-element error. Added a test for the "{0 " case.