### PR TITLE
[TEXT-179] Fix escaped nested variable pattern handling

### DIFF
--- a/src/main/java/org/apache/commons/text/StringSubstitutor.java
+++ b/src/main/java/org/apache/commons/text/StringSubstitutor.java
@@ -1455,13 +1455,22 @@ public class StringSubstitutor {
                         // found variable end marker
                         if (nestedVarCount == 0) {
                             if (escPos >= 0) {
+                                final boolean escapedVariableStartsWithNestedPrefix =
+                                        prefixMatcher.isMatch(builder, startPos + startMatchLen, offset, bufEnd) != 0;
+
+                                final boolean hasOuterSuffix =
+                                        hasLaterSuffix(builder, pos + endMatchLen, offset, bufEnd, suffixMatcher);
+
+                                pos = escapedVariableStartsWithNestedPrefix && !hasOuterSuffix
+                                        ? escPos
+                                        : startPos + 1;
+
                                 // delete escape
                                 builder.deleteCharAt(escPos);
                                 escPos = -1;
                                 lengthChange--;
                                 altered = true;
                                 bufEnd--;
-                                pos = startPos + 1;
                                 startPos--;
                                 continue outer;
                             }
@@ -1544,6 +1553,33 @@ public class StringSubstitutor {
             }
         }
         return new Result(altered, lengthChange);
+    }
+
+    /**
+     * Checks whether the specified buffer contains a variable suffix after the given position.
+     *
+     * @param builder the string builder to check, not null.
+     * @param pos the position to start checking from.
+     * @param offset the start offset within the builder, must be valid.
+     * @param bufEnd the end offset within the builder, must be valid.
+     * @param suffixMatcher the suffix matcher to use, not null.
+     * @return true if a suffix is found after the given position.
+     */
+    private boolean hasLaterSuffix(
+            final TextStringBuilder builder,
+            int pos,
+            final int offset,
+            final int bufEnd,
+            final StringMatcher suffixMatcher
+    ) {
+        while (pos < bufEnd) {
+            final int suffixLen = suffixMatcher.isMatch(builder, pos, offset, bufEnd);
+            if (suffixLen != 0) {
+                return true;
+            }
+            pos++;
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/StringSubstitutorTest.java
+++ b/src/test/java/org/apache/commons/text/StringSubstitutorTest.java
@@ -284,7 +284,6 @@ public class StringSubstitutorTest {
      * Tests interpolation with weird boundary patterns.
      */
     @Test
-    @Disabled
     void testReplace_JiraText178_WeirdPatterns3() throws IOException {
         doReplace("${${a}", "$${${a}", false); // not "$${1" or "${1"
     }


### PR DESCRIPTION
Fixes TEXT-179.

This change fixes the handling of escaped variable expressions that start with a nested variable prefix but do not contain a matching outer suffix.

Before this change, `$${${a}` was processed in a way that allowed the inner `${a}` expression to be resolved after the escape character was removed, producing `${1`.

The expected behavior is to keep the expression as `${${a}`, because the escaped outer expression should be treated as a whole and the inner prefix should not be processed independently in this incomplete boundary pattern.

The change preserves the existing behavior for complete escaped nested expressions such as `$${${a}}`, which still resolves to `${1}`, and for standard escaped expressions such as `$${animal}`, which still resolves to `${animal}`.

Added/enabled regression coverage in `StringSubstitutorTest`.