### PR TITLE
Use locale-independent lowercasing in case conversion helpers

### DIFF
--- a/src/main/java/org/apache/commons/text/CaseUtils.java
+++ b/src/main/java/org/apache/commons/text/CaseUtils.java
@@ -17,6 +17,7 @@
 package org.apache.commons.text;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -70,7 +71,7 @@ public class CaseUtils {
         if (StringUtils.isEmpty(str)) {
             return str;
         }
-        str = str.toLowerCase();
+        str = str.toLowerCase(Locale.ROOT);
         final int strLen = str.length();
         final int[] newCodePoints = new int[strLen];
         int outOffset = 0;

--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -17,6 +17,7 @@
 package org.apache.commons.text;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -250,7 +251,7 @@ public class WordUtils {
         if (StringUtils.isEmpty(str)) {
             return str;
         }
-        str = str.toLowerCase();
+        str = str.toLowerCase(Locale.ROOT);
         return capitalize(str, delimiters);
     }
 

--- a/src/main/java/org/apache/commons/text/lookup/StringLookupFactory.java
+++ b/src/main/java/org/apache/commons/text/lookup/StringLookupFactory.java
@@ -328,7 +328,7 @@ public final class StringLookupFactory {
             try {
                 for (final String lookupName : str.split("[\\s,]+")) {
                     if (!lookupName.isEmpty()) {
-                        addLookup(DefaultStringLookup.valueOf(lookupName.toUpperCase()), lookupMap);
+                        addLookup(DefaultStringLookup.valueOf(lookupName.toUpperCase(Locale.ROOT)), lookupMap);
                     }
                 }
             } catch (final IllegalArgumentException exc) {

--- a/src/test/java/org/apache/commons/text/CaseUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/CaseUtilsTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Tests {@link CaseUtils} class.
@@ -80,15 +80,10 @@ class CaseUtilsTest {
     }
 
     @Test
+    @DefaultLocale(language = "tr", country = "TR")
     void testToCamelCaseLocaleIndependent() {
-        final Locale dflt = Locale.getDefault();
-        try {
-            // Turkish lower-cases 'I' (U+0049) to dotless 'i' (U+0131), which would otherwise leak into the result.
-            Locale.setDefault(new Locale("tr", "TR"));
-            assertEquals("TipTop", CaseUtils.toCamelCase("TIP.TOP", true, '.'));
-            assertEquals("toCamelCase", CaseUtils.toCamelCase("TO CAMEL CASE", false, null));
-        } finally {
-            Locale.setDefault(dflt);
-        }
+        // Turkish lower-cases 'I' (U+0049) to dotless 'i' (U+0131), which would otherwise leak into the result.
+        assertEquals("TipTop", CaseUtils.toCamelCase("TIP.TOP", true, '.'));
+        assertEquals("toCamelCase", CaseUtils.toCamelCase("TO CAMEL CASE", false, null));
     }
 }

--- a/src/test/java/org/apache/commons/text/CaseUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/CaseUtilsTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -76,5 +77,18 @@ class CaseUtilsTest {
         assertEquals("\uD800\uDF00\uD800\uDF02", CaseUtils.toCamelCase("\uD800\uDF00 \uD800\uDF02", true));
         assertEquals("\uD800\uDF00\uD800\uDF01\uD800\uDF02\uD800\uDF03",
                 CaseUtils.toCamelCase("\uD800\uDF00\uD800\uDF01\uD800\uDF14\uD800\uDF02\uD800\uDF03", true, '\uD800', '\uDF14'));
+    }
+
+    @Test
+    void testToCamelCaseLocaleIndependent() {
+        final Locale dflt = Locale.getDefault();
+        try {
+            // Turkish lower-cases 'I' (U+0049) to dotless 'i' (U+0131), which would otherwise leak into the result.
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertEquals("TipTop", CaseUtils.toCamelCase("TIP.TOP", true, '.'));
+            assertEquals("toCamelCase", CaseUtils.toCamelCase("TO CAMEL CASE", false, null));
+        } finally {
+            Locale.setDefault(dflt);
+        }
     }
 }

--- a/src/test/java/org/apache/commons/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/WordUtilsTest.java
@@ -27,12 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Tests {@link WordUtils}.
@@ -126,16 +126,11 @@ class WordUtilsTest {
     }
 
     @Test
+    @DefaultLocale(language = "tr", country = "TR")
     void testCapitalizeFully_LocaleIndependent() {
-        final Locale dflt = Locale.getDefault();
-        try {
-            // Turkish lower-cases 'I' (U+0049) to dotless 'i' (U+0131), which would otherwise leak into the result.
-            Locale.setDefault(new Locale("tr", "TR"));
-            assertEquals("Heli World", WordUtils.capitalizeFully("HELI WORLD"));
-            assertEquals("I Am Here 123", WordUtils.capitalizeFully("I AM HERE 123"));
-        } finally {
-            Locale.setDefault(dflt);
-        }
+        // Turkish lower-cases 'I' (U+0049) to dotless 'i' (U+0131), which would otherwise leak into the result.
+        assertEquals("Heli World", WordUtils.capitalizeFully("HELI WORLD"));
+        assertEquals("I Am Here 123", WordUtils.capitalizeFully("I AM HERE 123"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/WordUtilsTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -122,6 +123,19 @@ class WordUtilsTest {
         assertEquals(WHITESPACE, WordUtils.capitalizeFully(WHITESPACE));
         assertEquals("A" + WHITESPACE + "B", WordUtils.capitalizeFully("a" + WHITESPACE + "b"));
 
+    }
+
+    @Test
+    void testCapitalizeFully_LocaleIndependent() {
+        final Locale dflt = Locale.getDefault();
+        try {
+            // Turkish lower-cases 'I' (U+0049) to dotless 'i' (U+0131), which would otherwise leak into the result.
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertEquals("Heli World", WordUtils.capitalizeFully("HELI WORLD"));
+            assertEquals("I Am Here 123", WordUtils.capitalizeFully("I AM HERE 123"));
+        } finally {
+            Locale.setDefault(dflt);
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/commons/text/lookup/StringLookupFactoryTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/StringLookupFactoryTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import javax.xml.XMLConstants;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 /**
@@ -171,6 +172,16 @@ class StringLookupFactoryTest {
         final Properties props = new Properties();
         props.setProperty(StringLookupFactory.DEFAULT_STRING_LOOKUPS_PROPERTY, "base64_encoder");
         checkDefaultStringLookupsHolder(props, "base64", StringLookupFactory.KEY_BASE64_ENCODER);
+    }
+
+    @Test
+    @DefaultLocale(language = "tr", country = "TR")
+    void testDefaultStringLookupsHolder_givenSingleLookup_localeIndependent() {
+        // Turkish upper-cases 'i' (U+0069) to dotted 'İ' (U+0130), so "file" would fold to "FİLE"
+        // and fail to resolve against the DefaultStringLookup enum without Locale.ROOT.
+        final Properties props = new Properties();
+        props.setProperty(StringLookupFactory.DEFAULT_STRING_LOOKUPS_PROPERTY, "file");
+        checkDefaultStringLookupsHolder(props, StringLookupFactory.KEY_FILE);
     }
 
     @Test


### PR DESCRIPTION
CaseUtils.toCamelCase and WordUtils.capitalizeFully fold their input to lower case with the no-arg String.toLowerCase(), so the output depends on the JVM default locale; under a Turkish locale an ASCII 'I' becomes the dotless 'ı' (U+0131), so capitalizeFully("HELI WORLD") comes back as "Helı World" rather than "Heli World" and toCamelCase("TIP.TOP", true, '.') yields "TıpTop". StringLookupFactory has the same issue when it upper-cases the default-lookups system property to match the enum names, which can stop a valid value like "file" from resolving on a Turkish JVM. I have switched all three sites to Locale.ROOT, matching the Locale.ROOT already used in StringLookupFactory.toKey, and added tests that pin the behaviour under a Turkish default locale.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
