### PR TITLE
Keep WordUtils.wrap from splitting a surrogate pair

### DIFF
--- a/src/main/java/org/apache/commons/text/WordUtils.java
+++ b/src/main/java/org/apache/commons/text/WordUtils.java
@@ -843,10 +843,14 @@ public class WordUtils {
                 if (matcherSize == 0) {
                     offset--;
                 }
-                // wrap really long word one line at a time
-                wrappedLine.append(str, offset, wrapLength + offset);
+                // wrap really long word one line at a time, but keep a surrogate pair whole
+                int wrapAt = wrapLength + offset;
+                if (Character.isHighSurrogate(str.charAt(wrapAt - 1)) && Character.isLowSurrogate(str.charAt(wrapAt))) {
+                    wrapAt++;
+                }
+                wrappedLine.append(str, offset, wrapAt);
                 wrappedLine.append(newLineStr);
-                offset += wrapLength;
+                offset = wrapAt;
                 matcherSize = -1;
             } else {
                 // do not wrap really long word, just extend beyond limit

--- a/src/test/java/org/apache/commons/text/WordUtilsTest.java
+++ b/src/test/java/org/apache/commons/text/WordUtilsTest.java
@@ -543,6 +543,14 @@ class WordUtilsTest {
         assertEquals(expected, WordUtils.wrap(input, 20, "\n", false));
         expected = "Click here,\nhttps://commons.apac\nhe.org, to jump to\nthe commons website";
         assertEquals(expected, WordUtils.wrap(input, 20, "\n", true));
+
+        // a hard break for a long word must not split a surrogate pair across the new line
+        input = "a\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";
+        expected = "a\uD83D\uDE00\uD83D\uDE00\n\uD83D\uDE00\uD83D\uDE00";
+        assertEquals(expected, WordUtils.wrap(input, 4, "\n", true));
+        input = "\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";
+        expected = "\uD83D\uDE00\uD83D\uDE00\n\uD83D\uDE00";
+        assertEquals(expected, WordUtils.wrap(input, 3, "\n", true));
     }
 
     @Test


### PR DESCRIPTION
Port of apache/commons-lang#1731 to the Commons Text copy of `WordUtils`, as requested by @garydgregory.

`WordUtils.wrap(str, wrapLength, newLineStr, true)` hard-breaks a too-long word at the fixed char offset `wrapLength + offset` and inserts the new line there. When that offset lands between the high and low surrogate of a supplementary code point the pair is split, so a lossless wrap emits a lone high surrogate at the end of one line and a lone low surrogate at the start of the next.

Repro: `WordUtils.wrap("a😀😀😀😀", 4, "\n", true)` (`a` then four `U+1F600`).
Before: `a😀\uD83D` `\n` `\uDE00😀\uD83D` `\n` `\uDE00`, i.e. the 2nd and 4th emoji are split around the `\n`.
After: `a😀😀\n😀😀`, no lone surrogates.

Fix: nudge the break one char forward when it would land inside a pair, so the whole code point stays on the current line. BMP input and the delimiter-based wrap paths are unaffected, and the other `wrap` overloads delegate to this method.

Added assertions to `WordUtilsTest#testWrap_StringIntStringBoolean` that fail on the current tree and pass with the fix.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
