### PR TITLE
Keep TextStringBuilder.reverse from splitting surrogate pairs

### DIFF
--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -2879,10 +2879,25 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         }
         final int half = size / 2;
         final char[] buf = buffer;
+        boolean hasSurrogates = false;
         for (int leftIdx = 0, rightIdx = size - 1; leftIdx < half; leftIdx++, rightIdx--) {
-            final char swap = buf[leftIdx];
-            buf[leftIdx] = buf[rightIdx];
-            buf[rightIdx] = swap;
+            final char left = buf[leftIdx];
+            final char right = buf[rightIdx];
+            buf[leftIdx] = right;
+            buf[rightIdx] = left;
+            hasSurrogates |= Character.isSurrogate(left) || Character.isSurrogate(right);
+        }
+        if (hasSurrogates) {
+            // The plain swap leaves each surrogate pair in low-high order; restore the high-low order so a
+            // reversed supplementary code point stays a valid pair, matching StringBuilder#reverse().
+            for (int i = 0; i < size - 1; i++) {
+                if (Character.isLowSurrogate(buf[i]) && Character.isHighSurrogate(buf[i + 1])) {
+                    final char low = buf[i];
+                    buf[i] = buf[i + 1];
+                    buf[i + 1] = low;
+                    i++;
+                }
+            }
         }
         return this;
     }

--- a/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
@@ -2138,6 +2138,21 @@ class TextStringBuilderTest {
     }
 
     @Test
+    void testReverseSurrogatePairs() {
+        // U+1F600 GRINNING FACE is a supplementary code point encoded as a surrogate pair; reversing
+        // must keep the pair intact (high before low) like StringBuilder, not split it into garbage.
+        final String emoji = "😀";
+        assertEquals(new StringBuilder("a" + emoji + "b").reverse().toString(), new TextStringBuilder("a" + emoji + "b").reverse().toString());
+        assertEquals("b" + emoji + "a", new TextStringBuilder("a" + emoji + "b").reverse().toString());
+
+        final String emoji2 = "😁";
+        assertEquals(emoji2 + emoji, new TextStringBuilder(emoji + emoji2).reverse().toString());
+
+        // An unpaired high surrogate has no partner and is left where it lands.
+        assertEquals("b\uD800a", new TextStringBuilder("a\uD800b").reverse().toString());
+    }
+
+    @Test
     void testRightString() {
         final TextStringBuilder sb = new TextStringBuilder("left right");
         assertEquals("right", sb.rightString(5));


### PR DESCRIPTION
Port of apache/commons-lang#1730 to the Commons Text copy of `TextStringBuilder`, as requested by @garydgregory.

`TextStringBuilder.reverse()` swaps the buffer one `char` at a time, so every surrogate pair is left in low-high order and a supplementary code point becomes malformed UTF-16. `StringBuilder`/`StringBuffer`, which this class is documented to mimic, reverse the same input correctly.

Repro: `new TextStringBuilder("a😀b").reverse().toString()` (`a`, `U+1F600`, `b`).
Before: `b\uDE00\uD83Da`, a low surrogate ahead of its high surrogate.
After: `b😀a`, matching `new StringBuilder("a😀b").reverse()`.

Fix: after the char swap, walk the buffer once and swap each adjacent low-high surrogate pair back to high-low, gated on whether any surrogate was seen during the swap. BMP text, lone unpaired surrogates and odd-length buffers are untouched.

Added `TextStringBuilderTest#testReverseSurrogatePairs`, which fails on the current tree and passes with the fix.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
