### PR TITLE
Reduce allocations in JaccardSimilarity and JaroWinklerSimilarity

### DIFF
--- a/src/main/java/org/apache/commons/text/similarity/JaccardSimilarity.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaccardSimilarity.java
@@ -78,17 +78,26 @@ public class JaccardSimilarity implements SimilarityScore<Double> {
         if (leftLength == 0 || rightLength == 0) {
             return 0d;
         }
-        final Set<E> leftSet = new HashSet<>();
+        final Set<E> leftSet = new HashSet<>(leftLength);
         for (int i = 0; i < leftLength; i++) {
             leftSet.add(left.at(i));
         }
-        final Set<E> rightSet = new HashSet<>();
+        final Set<E> rightSet = new HashSet<>(rightLength);
         for (int i = 0; i < rightLength; i++) {
             rightSet.add(right.at(i));
         }
-        final Set<E> unionSet = new HashSet<>(leftSet);
-        unionSet.addAll(rightSet);
-        final int intersectionSize = leftSet.size() + rightSet.size() - unionSet.size();
-        return 1.0d * intersectionSize / unionSet.size();
+        // |union| = |left| + |right| - |intersection|, so the intersection size is
+        // enough; counting it by probing the smaller set against the larger avoids
+        // building a third (union) set.
+        final Set<E> smallerSet = leftSet.size() <= rightSet.size() ? leftSet : rightSet;
+        final Set<E> largerSet = smallerSet == leftSet ? rightSet : leftSet;
+        int intersectionSize = 0;
+        for (final E element : smallerSet) {
+            if (largerSet.contains(element)) {
+                intersectionSize++;
+            }
+        }
+        final int unionSize = leftSet.size() + rightSet.size() - intersectionSize;
+        return 1.0d * intersectionSize / unionSize;
     }
 }

--- a/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java
+++ b/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.text.similarity;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -74,39 +73,32 @@ public class JaroWinklerSimilarity implements SimilarityScore<Double> {
             min = first;
         }
         final int range = Math.max(max.length() / 2 - 1, 0);
-        final int[] matchIndexes = new int[min.length()];
-        Arrays.fill(matchIndexes, -1);
+        final boolean[] minMatches = new boolean[min.length()];
         final boolean[] matchFlags = new boolean[max.length()];
         int matches = 0;
         for (int mi = 0; mi < min.length(); mi++) {
             final E c1 = min.at(mi);
             for (int xi = Math.max(mi - range, 0), xn = Math.min(mi + range + 1, max.length()); xi < xn; xi++) {
                 if (!matchFlags[xi] && c1.equals(max.at(xi))) {
-                    matchIndexes[mi] = xi;
+                    minMatches[mi] = true;
                     matchFlags[xi] = true;
                     matches++;
                     break;
                 }
             }
         }
-        final Object[] ms1 = new Object[matches];
-        final Object[] ms2 = new Object[matches];
-        for (int i = 0, si = 0; i < min.length(); i++) {
-            if (matchIndexes[i] != -1) {
-                ms1[si] = min.at(i);
-                si++;
-            }
-        }
-        for (int i = 0, si = 0; i < max.length(); i++) {
-            if (matchFlags[i]) {
-                ms2[si] = max.at(i);
-                si++;
-            }
-        }
+        // Count transpositions by walking the matched characters of each input in
+        // lockstep (min order vs. max order), without materializing them into arrays.
         int halfTranspositions = 0;
-        for (int mi = 0; mi < ms1.length; mi++) {
-            if (!ms1[mi].equals(ms2[mi])) {
-                halfTranspositions++;
+        for (int i = 0, j = 0; i < min.length(); i++) {
+            if (minMatches[i]) {
+                while (!matchFlags[j]) {
+                    j++;
+                }
+                if (!min.at(i).equals(max.at(j))) {
+                    halfTranspositions++;
+                }
+                j++;
             }
         }
         int prefix = 0;


### PR DESCRIPTION
## Summary

Two independent allocation reductions in the `similarity` package:

**1. `JaccardSimilarity.apply`** built three `HashSet`s per call: the distinct elements of each input, plus a *union* set (a copy of the left set with all right elements added) used only to obtain the union size. By the inclusion–exclusion identity `|A∪B| = |A| + |B| − |A∩B|`, the union set is unnecessary — count the intersection by probing the smaller distinct-element set against the larger and derive the union size arithmetically. The two remaining sets are inherent (the distinct elements of each input) and are now pre-sized to the input length.

**2. `JaroWinklerSimilarity` (`matches`)** materialized two `Object[]` arrays (the matched characters of each input) solely to count transpositions position-by-position, and tracked matched positions of the shorter input in an `int[]` where a `boolean` per position suffices. Count transpositions by walking the matched positions of both inputs in lockstep, comparing characters directly, and use a `boolean[]` for the match marks.

Behavior is unchanged in both.

## Measurement

ThreadMXBean allocation driver, 200k warmed ops, two 19-character inputs:

| method | before | after |
|--------|--------|-------|
| `JaccardSimilarity.apply` | 2408 B/op | 1448 B/op (−40%) |
| `JaroWinklerSimilarity` (matches) | 376 B/op | 144 B/op (−62%) |

## Testing

`JaccardSimilarityTest`, `JaccardDistanceTest`, `JaroWinklerSimilarityTest` and `JaroWinklerDistanceTest` pass unchanged (36 tests).
