### PR TITLE
Stop ExtendedMessageFormat seekNonWs reading past the pattern end

### DIFF
--- a/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
+++ b/src/main/java/org/apache/commons/text/ExtendedMessageFormat.java
@@ -478,12 +478,14 @@ public class ExtendedMessageFormat extends MessageFormat {
      * @param pos current position.
      */
     private void seekNonWs(final String pattern, final ParsePosition pos) {
-        int len = 0;
         final char[] buffer = pattern.toCharArray();
-        do {
-            len = StringMatcherFactory.INSTANCE.splitMatcher().isMatch(buffer, pos.getIndex(), 0, buffer.length);
+        while (pos.getIndex() < buffer.length) {
+            final int len = StringMatcherFactory.INSTANCE.splitMatcher().isMatch(buffer, pos.getIndex(), 0, buffer.length);
+            if (len == 0) {
+                break;
+            }
             pos.setIndex(pos.getIndex() + len);
-        } while (len > 0 && pos.getIndex() < pattern.length());
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/ExtendedMessageFormatTest.java
+++ b/src/test/java/org/apache/commons/text/ExtendedMessageFormatTest.java
@@ -236,6 +236,17 @@ class ExtendedMessageFormatTest {
         assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0 ", new HashMap<>()));
     }
 
+    @Test
+    void testTruncatedFormatElementWithRegistry() {
+        // A format element left unterminated at the end of the pattern used to make the
+        // registry-based constructor seek one past the buffer and throw
+        // ArrayIndexOutOfBoundsException; it should report the documented
+        // IllegalArgumentException, as the plain constructor already does.
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{", new HashMap<>()));
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0,", new HashMap<>()));
+        assertThrowsExactly(IllegalArgumentException.class, () -> new ExtendedMessageFormat("{0}extra{", new HashMap<>()));
+    }
+
     /**
      * Test the built in choice format.
      */


### PR DESCRIPTION
The registry-based ExtendedMessageFormat constructor parses its pattern with seekNonWs, which asks the split matcher about the character at the current parse index without first checking it is still inside the buffer. A truncated format element such as {, {0, or trailing text like {0}extra{ leaves the parse position at the end of the pattern, so the matcher reads one past the char array and the constructor throws ArrayIndexOutOfBoundsException rather than the documented IllegalArgumentException that the plain constructor already gives for the same input. This bounds the seek to the pattern length so those patterns report the usual unterminated-format-element error; a regression test covers the three shapes above.