### PR TITLE
Match String case folding in TextStringBuilder.equalsIgnoreCase

### DIFF
--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -1908,8 +1908,12 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
         for (int i = size - 1; i >= 0; i--) {
             final char c1 = thisBuf[i];
             final char c2 = otherBuf[i];
-            if (c1 != c2 && Character.toUpperCase(c1) != Character.toUpperCase(c2)) {
-                return false;
+            if (c1 != c2) {
+                final char u1 = Character.toUpperCase(c1);
+                final char u2 = Character.toUpperCase(c2);
+                if (u1 != u2 && Character.toLowerCase(u1) != Character.toLowerCase(u2)) {
+                    return false;
+                }
             }
         }
         return true;

--- a/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
@@ -974,6 +974,16 @@ class TextStringBuilderTest {
         sb2.set("aBc");
         assertTrue(sb1.equalsIgnoreCase(sb2));
 
+        // characters that only fold together via toLowerCase, matching String.equalsIgnoreCase
+        sb1.set("\u004B"); // LATIN CAPITAL LETTER K
+        sb2.set("\u212A"); // KELVIN SIGN, lower-cases to 'k'
+        assertTrue(sb1.equalsIgnoreCase(sb2));
+        assertTrue(sb2.equalsIgnoreCase(sb1));
+
+        sb1.set("\u00E5"); // LATIN SMALL LETTER A WITH RING ABOVE
+        sb2.set("\u212B"); // ANGSTROM SIGN, lower-cases to the same
+        assertTrue(sb1.equalsIgnoreCase(sb2));
+
         final Locale turkish = Locale.forLanguageTag("tr");
         assertTrue(new TextStringBuilder("title").equalsIgnoreCase(new TextStringBuilder("title".toLowerCase(turkish))));
         assertTrue(new TextStringBuilder("title").equalsIgnoreCase(new TextStringBuilder("TITLE".toLowerCase(turkish))));


### PR DESCRIPTION
Ports apache/commons-lang#1745 to `TextStringBuilder`, as requested there.

`Repro`: `new TextStringBuilder("K").equalsIgnoreCase(new TextStringBuilder("K"))` (KELVIN SIGN `U+212A` vs `K`) returns `false`, and so does the å/ANGSTROM pair `new TextStringBuilder("å").equalsIgnoreCase(new TextStringBuilder("Å"))`. `String.equalsIgnoreCase` returns `true` for both.

`Cause`: the per-character loop only rules a differing pair equal when `Character.toUpperCase(c1) == Character.toUpperCase(c2)`. Characters that fold together only through their lower-case mapping (`U+212A` -> `k`, `U+212B` -> `å`) fail that test, so the whole compare reports not-equal.

`Fix`: also accept the pair when `Character.toLowerCase` of the upper-cased chars agrees, the same fold `String#regionMatches` uses. Regression assertions added to `TextStringBuilderTest#testEqualsIgnoreCase` fail at the Kelvin pair without the main change and pass with it; all 124 tests in the class pass, and the default `mvn` build is green.

---

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
