### PR TITLE
[TEXT-241] TextStringBuilder.lastIndexOf("") and StrBuilder.lastIndexOf("") return incorrect index for empty string (size - 1 instead of size)

### DIFF
--- a/src/main/java/org/apache/commons/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/text/StrBuilder.java
@@ -2275,7 +2275,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str) {
-        return lastIndexOf(str, size - 1);
+        return lastIndexOf(str, size);
     }
 
     /**
@@ -2289,13 +2289,16 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str, int startIndex) {
-        startIndex = startIndex >= size ? size - 1 : startIndex;
+        startIndex = startIndex >= size ? size : startIndex;
         if (str == null || startIndex < 0) {
             return StringUtils.INDEX_NOT_FOUND;
         }
         final int strLen = str.length();
         if (strLen == 0) {
             return startIndex;
+        }
+        if (startIndex >= size) {
+            startIndex = size - 1;
         }
         if (strLen > size) {
             return StringUtils.INDEX_NOT_FOUND;

--- a/src/main/java/org/apache/commons/text/StrBuilder.java
+++ b/src/main/java/org/apache/commons/text/StrBuilder.java
@@ -2289,7 +2289,7 @@ public class StrBuilder implements CharSequence, Appendable, Serializable, Build
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str, int startIndex) {
-        startIndex = startIndex >= size ? size : startIndex;
+        startIndex = Math.min(startIndex, size);
         if (str == null || startIndex < 0) {
             return StringUtils.INDEX_NOT_FOUND;
         }

--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -2403,7 +2403,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str, int startIndex) {
-        startIndex = startIndex >= size ? size : startIndex;
+        startIndex = Math.min(startIndex, size);
         if (str == null || startIndex < 0) {
             return StringUtils.INDEX_NOT_FOUND;
         }

--- a/src/main/java/org/apache/commons/text/TextStringBuilder.java
+++ b/src/main/java/org/apache/commons/text/TextStringBuilder.java
@@ -2388,7 +2388,7 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str) {
-        return lastIndexOf(str, size - 1);
+        return lastIndexOf(str, size);
     }
 
     /**
@@ -2403,13 +2403,16 @@ public class TextStringBuilder implements CharSequence, Appendable, Serializable
      * @return The last index of the string, or -1 if not found.
      */
     public int lastIndexOf(final String str, int startIndex) {
-        startIndex = startIndex >= size ? size - 1 : startIndex;
+        startIndex = startIndex >= size ? size : startIndex;
         if (str == null || startIndex < 0) {
             return StringUtils.INDEX_NOT_FOUND;
         }
         final int strLen = str.length();
         if (strLen == 0) {
             return startIndex;
+        }
+        if (startIndex >= size) {
+            startIndex = size - 1;
         }
         if (strLen > size) {
             return StringUtils.INDEX_NOT_FOUND;

--- a/src/test/java/org/apache/commons/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/StrBuilderTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
  *
  * @deprecated This class will be removed in 2.0.
  */
+@Deprecated
 class StrBuilderTest {
 
     private static final class MockReadable implements Readable {

--- a/src/test/java/org/apache/commons/text/StrBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/StrBuilderTest.java
@@ -1220,6 +1220,9 @@ class StrBuilderTest {
         assertEquals(-1, sb.lastIndexOf("z"));
 
         assertEquals(-1, sb.lastIndexOf((String) null));
+
+        assertEquals(4, sb.lastIndexOf(""));
+        assertEquals("".lastIndexOf(""), new StringBuilder().lastIndexOf(""));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
+++ b/src/test/java/org/apache/commons/text/TextStringBuilderTest.java
@@ -1394,6 +1394,9 @@ class TextStringBuilderTest {
         assertEquals(-1, sb.lastIndexOf("z"));
 
         assertEquals(-1, sb.lastIndexOf((String) null));
+
+        assertEquals(4, sb.lastIndexOf(""));
+        assertEquals("".lastIndexOf(""), new StringBuilder().lastIndexOf(""));
     }
 
     @Test


### PR DESCRIPTION
`StrBuilder.lastIndexOf(String)` and `extStringBuilder.lastIndexOf(String)`
do not match `java.lang.String` / `StringBuilder` for the empty string.
 
For a builder of length n, `lastIndexOf("")` should return n (empty match
at the end). Both implementations currently return `n - 1`.
 
Cause:
`lastIndexOf(String, int) `clamps startIndex with:
`startIndex = startIndex >= size ? size - 1 : startIndex`
before the empty-string case, which returns that clamped index. So
`lastIndexOf("")` can never return size.
 
Example:
 

```
new StrBuilder("abab").lastIndexOf("") // actual 3, expected 4
"abab".lastIndexOf("") // 4
new StringBuilder("abab").lastIndexOf("") // 4
Same issue in TextStringBuilder.
```
 
Fix:
In `lastIndexOf(String, int)`, for an empty search string allow the start
index up to size and return that, keep the existing `size - 1` clamp for non-empty strings.
 
Affects:

- org.apache.commons.text.StrBuilder
- org.apache.commons.text.TextStringBuilder