### PR TITLE
[TEXT-242] StringSubstitutorReader now able to substitute variables whose configured suffix is longer than two characters

### DIFF
--- a/src/main/java/org/apache/commons/text/io/StringSubstitutorReader.java
+++ b/src/main/java/org/apache/commons/text/io/StringSubstitutorReader.java
@@ -273,7 +273,7 @@ public class StringSubstitutorReader extends FilterReader {
         while (true) {
             if (isBufferMatchAt(suffixMatcher, pos)) {
                 balance--;
-                pos++;
+                pos += suffixMatcher.size();
                 if (balance == 0) {
                     break;
                 }

--- a/src/test/java/org/apache/commons/text/io/StringSubstitutorFilterReaderTest.java
+++ b/src/test/java/org/apache/commons/text/io/StringSubstitutorFilterReaderTest.java
@@ -240,6 +240,22 @@ class StringSubstitutorFilterReaderTest extends StringSubstitutorTest {
         }
     }
 
+    @Test
+    void testReadSubstituteVariablesWithSuffixLongerThanTwoCharacters() throws IOException {
+        final StringSubstitutor substitutor = new StringSubstitutor(values);
+        final String template = "[[aaa]]>";
+        substitutor.setVariablePrefix("[[");
+        substitutor.setVariableSuffix("]]>");
+
+        try (Reader reader = createReader(substitutor, template)) {
+            final int endIndex = template.length() - 1;
+            final char[] cbuf = new char[endIndex];
+            final int readCount = reader.read(cbuf);
+            final String result = new String(cbuf, 0, readCount);
+            assertEquals("111", result);
+        }
+    }
+
     private Reader toReader(final String expectedResult) {
         return expectedResult != null ? new StringReader(expectedResult) : new NullReader();
     }


### PR DESCRIPTION
Jira ticket is [TEXT-242](https://issues.apache.org/jira/browse/TEXT-242)