### PR TITLE
Fix ArrayIndexOutOfBoundsException in DnsStringLookup for '|' key

### DIFF
--- a/src/main/java/org/apache/commons/text/lookup/DnsStringLookup.java
+++ b/src/main/java/org/apache/commons/text/lookup/DnsStringLookup.java
@@ -87,6 +87,9 @@ final class DnsStringLookup extends AbstractStringLookup {
         }
         final String[] keys = key.trim().split("\\|");
         final int keyLen = keys.length;
+        if (keyLen == 0) {
+            return null;
+        }
         final String subKey = keys[0].trim();
         final String subValue = keyLen < 2 ? key : keys[1].trim();
         try {

--- a/src/test/java/org/apache/commons/text/lookup/DnsStringLookupTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/DnsStringLookupTest.java
@@ -74,6 +74,14 @@ class DnsStringLookupTest {
     }
 
     @Test
+    void testDelimiterOnlyKey() {
+        // A key that is only delimiter/whitespace splits to an empty array; must not throw.
+        assertNull(DnsStringLookup.INSTANCE.apply("|"));
+        assertNull(DnsStringLookup.INSTANCE.apply("||"));
+        assertNull(DnsStringLookup.INSTANCE.apply("  |  "));
+    }
+
+    @Test
     void testNull() {
         assertNull(DnsStringLookup.INSTANCE.apply(null));
     }


### PR DESCRIPTION
`DnsStringLookup.lookup` splits the key on `|` and reads `keys[0]` before it checks the array length, so a key made up of only delimiter or whitespace characters (for example the interpolation `${dns:|}`, or `||`) splits to an empty array and throws an `ArrayIndexOutOfBoundsException` straight out of the public lookup instead of resolving to nothing. Every other split-based lookup in this package (`FileStringLookup`, `UrlStringLookup`, `PropertiesStringLookup`, `XmlStringLookup`, `ScriptStringLookup`, `ResourceBundleStringLookup`) guards the length before indexing, so this is the odd one out. I've returned `null` for that case, which is what the method already does for a null key and for a host that will not resolve, so the behaviour stays consistent and no valid key changes.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
