### PR TITLE
LevenshteinDetailedDistance reports a distance larger than the Levenshtein distance

### DIFF
--- a/src/main/java/org/apache/commons/text/similarity/LevenshteinDetailedDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/LevenshteinDetailedDistance.java
@@ -53,69 +53,34 @@ public class LevenshteinDetailedDistance implements EditDistance<LevenshteinResu
         int subCount = 0;
         int rowIndex = right.length();
         int columnIndex = left.length();
-        int dataAtLeft = 0;
-        int dataAtTop = 0;
-        int dataAtDiagonal = 0;
-        int data = 0;
-        boolean deleted = false;
-        boolean added = false;
-        while (rowIndex >= 0 && columnIndex >= 0) {
-            if (columnIndex == 0) {
-                dataAtLeft = -1;
-            } else {
-                dataAtLeft = matrix[rowIndex][columnIndex - 1];
-            }
-            if (rowIndex == 0) {
-                dataAtTop = -1;
-            } else {
-                dataAtTop = matrix[rowIndex - 1][columnIndex];
-            }
-            if (rowIndex > 0 && columnIndex > 0) {
-                dataAtDiagonal = matrix[rowIndex - 1][columnIndex - 1];
-            } else {
-                dataAtDiagonal = -1;
-            }
-            if (dataAtLeft == -1 && dataAtTop == -1 && dataAtDiagonal == -1) {
-                break;
-            }
-            data = matrix[rowIndex][columnIndex];
-            // case in which the character at left and right are the same,
-            // in this case none of the counters will be incremented.
-            if (columnIndex > 0 && rowIndex > 0 && left.at(columnIndex - 1).equals(right.at(rowIndex - 1))) {
-                columnIndex--;
+        // Walk back from the last cell, taking only steps whose predecessor holds this cell's value less the step cost.
+        while (rowIndex > 0 || columnIndex > 0) {
+            final int data = matrix[rowIndex][columnIndex];
+            if (rowIndex > 0 && columnIndex > 0 && matrix[rowIndex - 1][columnIndex - 1] == data
+                    && left.at(columnIndex - 1).equals(right.at(rowIndex - 1))) {
                 rowIndex--;
-                continue;
-            }
-            // handling insert and delete cases.
-            deleted = false;
-            added = false;
-            if (data - 1 == dataAtLeft && data <= dataAtDiagonal && data <= dataAtTop || dataAtDiagonal == -1 && dataAtTop == -1) { // NOPMD
+                columnIndex--;
+            } else if (columnIndex > 0 && matrix[rowIndex][columnIndex - 1] == data - 1) {
                 columnIndex--;
                 if (swapped) {
                     addCount++;
-                    added = true;
                 } else {
                     delCount++;
-                    deleted = true;
                 }
-            } else if (data - 1 == dataAtTop && data <= dataAtDiagonal && data <= dataAtLeft || dataAtDiagonal == -1 && dataAtLeft == -1) { // NOPMD
+            } else if (rowIndex > 0 && matrix[rowIndex - 1][columnIndex] == data - 1) {
                 rowIndex--;
                 if (swapped) {
                     delCount++;
-                    deleted = true;
                 } else {
                     addCount++;
-                    added = true;
                 }
-            }
-            // substituted case
-            if (!added && !deleted) {
+            } else {
                 subCount++;
-                columnIndex--;
                 rowIndex--;
+                columnIndex--;
             }
         }
-        return new LevenshteinResults(addCount + delCount + subCount, addCount, delCount, subCount);
+        return new LevenshteinResults(matrix[right.length()][left.length()], addCount, delCount, subCount);
     }
 
     /**

--- a/src/test/java/org/apache/commons/text/similarity/LevenshteinDetailedDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/LevenshteinDetailedDistanceTest.java
@@ -19,6 +19,10 @@ package org.apache.commons.text.similarity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import org.apache.commons.text.TextStringBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -477,6 +481,35 @@ class LevenshteinDetailedDistanceTest {
         actualResult = classBeingTested.apply("", "a");
         expectedResult = new LevenshteinResults(1, 1, 0, 0);
         assertEquals(expectedResult.toString(), actualResult.toString());
+    }
+
+    /**
+     * The detailed distance must equal {@link LevenshteinDistance} for the same pair, and the edit counts must sum to it.
+     */
+    @Test
+    void testDistanceAgreesWithLevenshteinDistance() {
+        final LevenshteinDistance plain = LevenshteinDistance.getDefaultInstance();
+        assertEquals(2, plain.apply("aba", "bab"));
+        assertEquals(2, UNLIMITED_DISTANCE.apply("aba", "bab").getDistance());
+        final List<String> corpus = new ArrayList<>();
+        final Random random = new Random(20260902L);
+        for (int i = 0; i < 120; i++) {
+            final StringBuilder builder = new StringBuilder();
+            final int length = random.nextInt(9);
+            for (int j = 0; j < length; j++) {
+                builder.append((char) ('a' + random.nextInt(3)));
+            }
+            corpus.add(builder.toString());
+        }
+        for (final String left : corpus) {
+            for (final String right : corpus) {
+                final LevenshteinResults results = UNLIMITED_DISTANCE.apply(left, right);
+                assertEquals(plain.apply(left, right), results.getDistance(), () -> "distance for [" + left + "] -> [" + right + "]");
+                assertEquals(results.getDistance().intValue(),
+                        results.getInsertCount() + results.getDeleteCount() + results.getSubstituteCount(),
+                        () -> "edit counts must sum to the distance for [" + left + "] -> [" + right + "]");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
`LevenshteinDetailedDistance.getDefaultInstance().apply("aba", "bab").getDistance()` returns 3; `LevenshteinDistance.getDefaultInstance().apply("aba", "bab")` returns 2.

`findDetailedResults` returns `addCount + delCount + subCount` from a backtrace that chooses insert or delete whenever the neighbouring cell is one less, without checking that the step is on a shortest path. On "aba" -> "bab" that walk takes three steps where the matrix supports two.

The walk now takes a step only when the predecessor cell holds the current value less the step's cost, and the distance is read from `matrix[m][n]`. Edit counts sum to the distance; the counts on the existing tests are unchanged.

Verified with the default `mvn` goal (1892 tests, checkstyle, PMD, SpotBugs, japicmp). The new test fails on master with `expected: <2> but was: <3>`.

Found by an automated review loop I run; the fix and test were reviewed and verified by me.
