### PR TITLE
Follow symbolic links in PathFence

### DIFF
--- a/src/main/java/org/apache/commons/text/lookup/PathFence.java
+++ b/src/main/java/org/apache/commons/text/lookup/PathFence.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.text.lookup;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -27,6 +29,10 @@ import java.util.stream.Collectors;
 
 /**
  * A Path fence guards against using paths outside of a "fence" of made of root paths.
+ *
+ * <p>
+ * Roots and the path under test are resolved to their real locations, so a symbolic link inside a fence cannot escape it.
+ * </p>
  *
  * Keep package-private.
  */
@@ -114,8 +120,28 @@ final class PathFence {
         return roots.isEmpty();
     }
 
+    /**
+     * Resolves the deepest existing ancestor with {@link Path#toRealPath(java.nio.file.LinkOption...)} and re-attaches the remaining segments.
+     *
+     * @param path The path to resolve.
+     * @return The real path, absolute and normalized.
+     * @throws IllegalArgumentException if the path exists but cannot be resolved.
+     */
     private Path normalize(final Path path) {
-        return path.toAbsolutePath().normalize();
+        final Path absolute = path.toAbsolutePath().normalize();
+        Path existing = absolute;
+        while (existing != null && !Files.exists(existing)) {
+            existing = existing.getParent();
+        }
+        if (existing == null) {
+            return absolute;
+        }
+        try {
+            final Path real = existing.toRealPath();
+            return existing.equals(absolute) ? real : real.resolve(existing.relativize(absolute)).normalize();
+        } catch (final IOException e) {
+            throw new IllegalArgumentException(String.format("[%s] cannot be resolved to a real path", path), e);
+        }
     }
 
 }

--- a/src/test/java/org/apache/commons/text/lookup/PathFenceTest.java
+++ b/src/test/java/org/apache/commons/text/lookup/PathFenceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.commons.text.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests {@link PathFence}.
+ */
+class PathFenceTest {
+
+    private static final String SECRET = "TOP-SECRET";
+
+    @TempDir
+    private Path tempDir;
+
+    /** Aborts the test where the platform cannot create symbolic links, for example Windows without developer mode. */
+    private void createSymbolicLink(final Path link, final Path target) {
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (final IOException | UnsupportedOperationException e) {
+            Assumptions.abort("This platform cannot create symbolic links: " + e);
+        }
+    }
+
+    @Test
+    void testPathInsideFenceIsAccepted() throws IOException {
+        final Path inside = Files.createDirectories(tempDir.resolve("in"));
+        final Path file = Files.write(inside.resolve("ok.txt"), "INSIDE".getBytes(StandardCharsets.UTF_8));
+        final StringLookup lookup = StringLookupFactory.builder().setFences(inside).get().fileStringLookup();
+        assertEquals("INSIDE", lookup.lookup("UTF-8:" + file));
+    }
+
+    @Test
+    void testRelativeTraversalOutOfFenceIsRejected() throws IOException {
+        final Path inside = Files.createDirectories(tempDir.resolve("in"));
+        final Path outside = Files.createDirectories(tempDir.resolve("out"));
+        Files.write(outside.resolve("secret.txt"), SECRET.getBytes(StandardCharsets.UTF_8));
+        final StringLookup lookup = StringLookupFactory.builder().setFences(inside).get().fileStringLookup();
+        assertThrows(IllegalArgumentException.class, () -> lookup.lookup("UTF-8:" + inside.resolve("../out/secret.txt")));
+    }
+
+    @Test
+    void testSymbolicLinkInsideFenceIsRejected() throws IOException {
+        final Path inside = Files.createDirectories(tempDir.resolve("in"));
+        final Path outside = Files.createDirectories(tempDir.resolve("out"));
+        final Path secret = Files.write(outside.resolve("secret.txt"), SECRET.getBytes(StandardCharsets.UTF_8));
+        final Path link = inside.resolve("link.txt");
+        createSymbolicLink(link, secret);
+        final StringLookup lookup = StringLookupFactory.builder().setFences(inside).get().fileStringLookup();
+        assertThrows(IllegalArgumentException.class, () -> lookup.lookup("UTF-8:" + link));
+    }
+
+    @Test
+    void testSymbolicLinkFenceRootResolvesToItsTarget() throws IOException {
+        final Path real = Files.createDirectories(tempDir.resolve("real"));
+        final Path file = Files.write(real.resolve("ok.txt"), "INSIDE".getBytes(StandardCharsets.UTF_8));
+        final Path linkedRoot = tempDir.resolve("linked");
+        createSymbolicLink(linkedRoot, real);
+        final StringLookup lookup = StringLookupFactory.builder().setFences(linkedRoot).get().fileStringLookup();
+        assertEquals("INSIDE", lookup.lookup("UTF-8:" + file));
+    }
+}


### PR DESCRIPTION
`PathFence.normalize` uses `toAbsolutePath().normalize()`, which removes `..` segments but does not follow symbolic links. A link inside a fence that points outside it passes the fence:

```java
Files.createSymbolicLink(inside.resolve("link.txt"), outside.resolve("secret.txt"));
StringLookupFactory.builder().setFences(inside).get().fileStringLookup().lookup("UTF-8:" + inside.resolve("link.txt"));
// returns the contents of outside/secret.txt
```

Same class of bypass as #745, via links instead of `..`.

Resolve the deepest existing ancestor with `toRealPath()` and re-attach the remaining segments; a path that does not exist yet has no link to follow. Fence roots go through the same method, so a root that is itself a link still fences its target. New `PathFenceTest` covers both link cases and aborts where the platform cannot create links.

Default `mvn` goal passes on JDK 21, 1895 tests.

Found by an automated audit loop (Claude); patch and description reviewed by me.
