### PR TITLE
Compare characters by value in DamerauLevenshteinDistance

### DIFF
--- a/src/main/java/org/apache/commons/text/similarity/DamerauLevenshteinDistance.java
+++ b/src/main/java/org/apache/commons/text/similarity/DamerauLevenshteinDistance.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.text.similarity;
 
+import java.util.Objects;
+
 /**
  * An algorithm for measuring the difference between two character sequences using the
  * <a href="https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance">Damerau-Levenshtein Distance</a>.
@@ -32,7 +34,7 @@ public class DamerauLevenshteinDistance implements EditDistance<Integer> {
 
     private static <E> int calculateCost(final SimilarityInput<E> left, final SimilarityInput<E> right, final int leftIndex, final int rightIndex,
             final int[] curr, final int[] prev, final int[] prevPrev) {
-        final int cost = left.at(leftIndex - 1) == right.at(rightIndex - 1) ? 0 : 1;
+        final int cost = Objects.equals(left.at(leftIndex - 1), right.at(rightIndex - 1)) ? 0 : 1;
         // Select cheapest operation
         int value = Math.min(
                 Math.min(
@@ -44,8 +46,8 @@ public class DamerauLevenshteinDistance implements EditDistance<Integer> {
         // Check if adjacent characters are the same -> transpose if cheaper
         if (leftIndex > 1
                 && rightIndex > 1
-                && left.at(leftIndex - 1) == right.at(rightIndex - 2)
-                && left.at(leftIndex - 2) == right.at(rightIndex - 1)) {
+                && Objects.equals(left.at(leftIndex - 1), right.at(rightIndex - 2))
+                && Objects.equals(left.at(leftIndex - 2), right.at(rightIndex - 1))) {
             // Use cost here, to properly handle two subsequent equal letters
             value = Math.min(value, prevPrev[rightIndex - 2] + cost);
         }

--- a/src/test/java/org/apache/commons/text/similarity/DamerauLevenshteinDistanceTest.java
+++ b/src/test/java/org/apache/commons/text/similarity/DamerauLevenshteinDistanceTest.java
@@ -77,7 +77,14 @@ public class DamerauLevenshteinDistanceTest {
                 Arguments.of("xyxyxyxyxy", "yxyxyxyxyx", 4, 2),
                 Arguments.of("aaaaabbbbbccccc", "cccccbbbbbaaaaa", 5, -1),
                 Arguments.of("thequickbrownfoxjumpsoverthelazydog", "thequickbrownfoxjumpsovrethelazydog", 1, 1),
-                Arguments.of("antidisestablishmentarianism", "antidisestablishmentarianisn", 3, 1)
+                Arguments.of("antidisestablishmentarianism", "antidisestablishmentarianisn", 3, 1),
+                // Non-ASCII characters are outside the Character.valueOf cache, so identical inputs must still measure zero.
+                Arguments.of("caf\u00e9", "caf\u00e9", 1, 0),
+                Arguments.of("\u4f60\u597d", "\u4f60\u597d", 1, 0),
+                Arguments.of("na\u00efve", "na\u00efve", 1, 0),
+                // Transposing two adjacent non-ASCII characters costs one edit, exactly as it does for ASCII.
+                Arguments.of("caf\u00e9\u00e8", "caf\u00e8\u00e9", 1, 1),
+                Arguments.of("\u4f60\u597d", "\u597d\u4f60", 1, 1)
         );
     }
 
@@ -123,7 +130,16 @@ public class DamerauLevenshteinDistanceTest {
                 Arguments.of("xyxyxyxyxy", "yxyxyxyxyx", 2),
                 Arguments.of("aaaaabbbbbccccc", "cccccbbbbbaaaaa", 10),
                 Arguments.of("thequickbrownfoxjumpsoverthelazydog", "thequickbrownfoxjumpsovrethelazydog", 1),
-                Arguments.of("antidisestablishmentarianism", "antidisestablishmentarianisn", 1)
+                Arguments.of("antidisestablishmentarianism", "antidisestablishmentarianisn", 1),
+                // Non-ASCII characters are outside the Character.valueOf cache, so identical inputs must still measure zero.
+                Arguments.of("caf\u00e9", "caf\u00e9", 0),
+                Arguments.of("\u4f60\u597d", "\u4f60\u597d", 0),
+                Arguments.of("na\u00efve", "na\u00efve", 0),
+                Arguments.of("\ud83d\ude00", "\ud83d\ude00", 0),
+                // Transposing two adjacent non-ASCII characters costs one edit, exactly as it does for ASCII.
+                Arguments.of("caf\u00e9\u00e8", "caf\u00e8\u00e9", 1),
+                Arguments.of("\u4f60\u597d", "\u597d\u4f60", 1),
+                Arguments.of("\u00e9x", "x\u00e9", 1)
         );
     }
 


### PR DESCRIPTION
calculateCost compared the boxed Character values returned by
`SimilarityInput.at` with `==`, so it only recognized equal characters
that `Character.valueOf` caches. That cache covers values up to 127,
so every non-ASCII character compared unequal to itself: applying the
distance to `"caf\u00e9"` and `"caf\u00e9"` reported 1 instead of 0,
and a two-character CJK input compared against itself reported 2. The
adjacent-transposition branch never fired for non-ASCII input either,
so transposing two accented characters cost 2 instead of 1. The
limited variant was affected the same way and could return -1 for
inputs whose real distance is within the threshold.

Compare with `Objects.equals` instead, matching every other class in
this package: `LevenshteinDistance`, `LevenshteinDetailedDistance`,
`JaroWinklerSimilarity` and `HammingDistance` all use `equals` on the
values from `at`.

---

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? **Codex (OpenAI GPT-5) was used to discover the bug via automated property-based testing, propose the fix, write the regression tests, and craft this description. Every change was reviewed and verified by a human contributor.**
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that is `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.